### PR TITLE
morefollows is not optional

### DIFF
--- a/src/mms/iso_mms/server/mms_file_service.c
+++ b/src/mms/iso_mms/server/mms_file_service.c
@@ -960,8 +960,7 @@ createFileDirectoryResponse(const char* basepath, uint32_t invokeId, ByteBuffer*
 
     bufPos += tempEncoded;
 
-    if (moreFollows)
-        bufPos = BerEncoder_encodeBoolean(0x81, moreFollows, buffer, bufPos);
+    bufPos = BerEncoder_encodeBoolean(0x81, moreFollows, buffer, bufPos);
 
     response->size = bufPos;
 }


### PR DESCRIPTION
from mms asn1 defs

FileRead-Response ::= SEQUENCE {
fileData	[0] IMPLICIT OCTET STRING,
moreFollows	[1] IMPLICIT BOOLEAN DEFAULT TRUE
}
This patch makes it so the moreFollows field is always present.