### PR TITLE
Sampled Values: fix encoding of optional smpMod attribute:

### DIFF
--- a/src/sampled_values/sv_publisher.c
+++ b/src/sampled_values/sv_publisher.c
@@ -377,15 +377,11 @@ SV_ASDU_encodeToBuffer(SV_ASDU self, uint8_t* buffer, int bufPos)
     self->_dataBuffer = buffer + bufPos;
 
     bufPos += self->dataSize; /* data has to inserted by user before sending message */
-
+    
     /* SmpMod */
     if (self->hasSmpMod) {
-        bufPos = BerEncoder_encodeTL(0x84, 4, buffer, bufPos);
-        buffer[bufPos++] = 0;
-        buffer[bufPos++] = 0;
-        buffer[bufPos++] = 0;
-        buffer[bufPos++] = self->smpMod;
-
+        bufPos = BerEncoder_encodeTL(0x88, 4, buffer, bufPos);
+        bufPos = encodeUint16FixedSize(self->smpMod, buffer, bufPos);
     }
 
     return bufPos;


### PR DESCRIPTION
- The attribute must be encoded as an 16bit unsigned integer. The existing code encodes it as 32 bit integer.
- The attribute is encoded with the ASN.1 BER encoding Tag number 8. The existing code encodes it with tag number 4 which is used for the refrTm attribute.

See also: IEC 61850-9-2:2011 (page 20)