### PR TITLE
EthernetHandleSet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ set(API_HEADERS
     src/hal/inc/hal_time.h 
     src/hal/inc/hal_thread.h
     src/hal/inc/hal_filesystem.h 
+    src/hal/inc/hal_ethernet.h
     src/hal/inc/platform_endian.h
     src/common/inc/libiec61850_common_api.h
     src/common/inc/libiec61850_platform_includes.h

--- a/examples/goose_subscriber/goose_subscriber_example.c
+++ b/examples/goose_subscriber/goose_subscriber_example.c
@@ -7,6 +7,7 @@
  */
 
 #include "goose_receiver.h"
+#include "goose_subscriber.h"
 #include "hal_thread.h"
 
 #include <stdlib.h>

--- a/src/goose/goose_receiver.c
+++ b/src/goose/goose_receiver.c
@@ -811,3 +811,10 @@ GooseReceiver_tick(GooseReceiver self)
     else
         return false;
 }
+
+void
+GooseReceiver_addHandleSet(GooseReceiver self, EthernetHandleSet handles)
+{
+    return EthernetHandleSet_addSocket(handles, self->ethSocket);
+}
+

--- a/src/goose/goose_receiver.h
+++ b/src/goose/goose_receiver.h
@@ -133,6 +133,20 @@ GooseReceiver_stopThreadless(GooseReceiver self);
 bool
 GooseReceiver_tick(GooseReceiver self);
 
+/* Forward declaration */
+typedef struct sEthernetHandleSet* EthernetHandleSet;
+
+/**
+ * \brief Add the receiver to a handleset for multiplexed asynchronous IO.
+ *
+ * Note: This function must only be called after GooseReceiver_startThreadless().
+ *
+ * \param[in] self The SVReceiver instance.
+ * \param[inout] handles The EthernetHandleSet to which the EthernetSocket of this receiver should be added.
+ */
+void
+GooseReceiver_addHandleSet(GooseReceiver self, EthernetHandleSet handles);
+
 /**@}*/
 
 #ifdef __cplusplus

--- a/src/goose/goose_receiver.h
+++ b/src/goose/goose_receiver.h
@@ -24,11 +24,11 @@
 #ifndef GOOSE_RECEIVER_H_
 #define GOOSE_RECEIVER_H_
 
-#include <goose_subscriber.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <stdbool.h>
 
 
 /**
@@ -36,6 +36,7 @@ extern "C" {
  */
 /**@{*/
 
+typedef struct sGooseSubscriber* GooseSubscriber;
 
 typedef struct sGooseReceiver* GooseReceiver;
 

--- a/src/hal/ethernet/bsd/ethernet_bsd.c
+++ b/src/hal/ethernet/bsd/ethernet_bsd.c
@@ -81,7 +81,8 @@ void
 EthernetHandleSet_removeSocket(EthernetHandleSet self, const EthernetSocket sock)
 {
     if ((self != NULL) && (sock != NULL)) {
-        for (unsigned i = 0; i < self->nhandles; i++) {
+        unsigned i;
+        for (i = 0; i < self->nhandles; i++) {
             if (self->handles[i].fd == sock->bpf) {
                 memmove(&self->handles[i], &self->handles[i+1], sizeof(struct pollfd) * (self->nhandles - i - 1));
                 self->nhandles--;

--- a/src/hal/ethernet/bsd/ethernet_bsd.c
+++ b/src/hal/ethernet/bsd/ethernet_bsd.c
@@ -22,6 +22,7 @@
  */
 #include <sys/socket.h>
 #include <sys/ioctl.h>
+#include <sys/select.h>
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <net/if.h>
@@ -47,6 +48,58 @@ struct sEthernetSocket {
 };
 
 int _Ethernet_activateBpdFilter(EthernetSocket self)
+struct sEthernetHandleSet {
+    fd_set handles;
+    int maxHandle;
+};
+
+EthernetHandleSet
+EthernetHandleSet_new(void)
+{
+    EthernetHandleSet result = (EthernetHandleSet) GLOBAL_MALLOC(sizeof(struct sEthernetHandleSet));
+
+    if (result != NULL) {
+        FD_ZERO(&result->handles);
+        result->maxHandle = -1;
+    }
+    return result;
+}
+
+void
+EthernetHandleSet_addSocket(EthernetHandleSet self, const EthernetSocket sock)
+{
+    if (self != NULL && sock != NULL && sock->bpf != -1) {
+        FD_SET(sock->bpf, &self->handles);
+        if (sock->bpf > self->maxHandle) {
+            self->maxHandle = sock->bpf;
+        }
+    }
+}
+
+int
+EthernetHandleSet_waitReady(EthernetHandleSet self, unsigned int timeoutMs)
+{
+    int result;
+
+    if ((self != NULL) && (self->maxHandle >= 0)) {
+        struct timeval timeout;
+
+        timeout.tv_sec = timeoutMs / 1000;
+        timeout.tv_usec = (timeoutMs % 1000) * 1000;
+        result = select(self->maxHandle + 1, &self->handles, NULL, NULL, &timeout);
+    } else {
+        result = -1;
+    }
+    
+    return result;
+}
+
+void
+EthernetHandleSet_destroy(EthernetHandleSet self)
+{
+    GLOBAL_FREEMEM(self);
+}
+
 {
     return ioctl(self->bpf, BIOCSETF, &self->bpfProgram);
 }

--- a/src/hal/ethernet/bsd/ethernet_bsd.c
+++ b/src/hal/ethernet/bsd/ethernet_bsd.c
@@ -77,6 +77,20 @@ EthernetHandleSet_addSocket(EthernetHandleSet self, const EthernetSocket sock)
     }
 }
 
+void
+EthernetHandleSet_removeSocket(EthernetHandleSet self, const EthernetSocket sock)
+{
+    if ((self != NULL) && (sock != NULL)) {
+        for (unsigned i = 0; i < self->nhandles; i++) {
+            if (self->handles[i].fd == sock->bpf) {
+                memmove(&self->handles[i], &self->handles[i+1], sizeof(struct pollfd) * (self->nhandles - i - 1));
+                self->nhandles--;
+                return;
+            }
+        }
+    }
+}
+
 int
 EthernetHandleSet_waitReady(EthernetHandleSet self, unsigned int timeoutMs)
 {

--- a/src/hal/ethernet/linux/ethernet_linux.c
+++ b/src/hal/ethernet/linux/ethernet_linux.c
@@ -71,6 +71,20 @@ EthernetHandleSet_addSocket(EthernetHandleSet self, const EthernetSocket sock)
     }
 }
 
+void
+EthernetHandleSet_removeSocket(EthernetHandleSet self, const EthernetSocket sock)
+{
+    if ((self != NULL) && (sock != NULL)) {
+        for (unsigned i = 0; i < self->nhandles; i++) {
+            if (self->handles[i].fd == sock->rawSocket) {
+                memmove(&self->handles[i], &self->handles[i+1], sizeof(struct pollfd) * (self->nhandles - i - 1));
+                self->nhandles--;
+                return;
+            }
+        }
+    }
+}
+
 int
 EthernetHandleSet_waitReady(EthernetHandleSet self, unsigned int timeoutMs)
 {

--- a/src/hal/ethernet/linux/ethernet_linux.c
+++ b/src/hal/ethernet/linux/ethernet_linux.c
@@ -75,7 +75,8 @@ void
 EthernetHandleSet_removeSocket(EthernetHandleSet self, const EthernetSocket sock)
 {
     if ((self != NULL) && (sock != NULL)) {
-        for (unsigned i = 0; i < self->nhandles; i++) {
+        unsigned i;
+        for (i = 0; i < self->nhandles; i++) {
             if (self->handles[i].fd == sock->rawSocket) {
                 memmove(&self->handles[i], &self->handles[i+1], sizeof(struct pollfd) * (self->nhandles - i - 1));
                 self->nhandles--;

--- a/src/hal/ethernet/win32/ethernet_win32.c
+++ b/src/hal/ethernet/win32/ethernet_win32.c
@@ -145,6 +145,22 @@ EthernetHandleSet_addSocket(EthernetHandleSet self, const EthernetSocket sock)
     }
 }
 
+void
+EthernetHandleSet_removeSocket(EthernetHandleSet self, const EthernetSocket sock)
+{
+    if ((self != NULL) && (sock != NULL)) {
+        HANDLE h = pcap_getevent(socket->rawSocket);
+
+        for (unsigned i = 0; i < self->nhandles; i++) {
+            if (self->handles[i] == h) {
+                memmove(&self->handles[i], &self->handles[i+1], sizeof(HANDLE) * (self->nhandles - i - 1));
+                self->nhandles--;
+                return;
+            }
+        }
+    }
+}
+
 int
 EthernetHandleSet_waitReady(EthernetHandleSet self, unsigned int timeoutMs)
 {

--- a/src/hal/ethernet/win32/ethernet_win32.c
+++ b/src/hal/ethernet/win32/ethernet_win32.c
@@ -151,7 +151,8 @@ EthernetHandleSet_removeSocket(EthernetHandleSet self, const EthernetSocket sock
     if ((self != NULL) && (sock != NULL)) {
         HANDLE h = pcap_getevent(socket->rawSocket);
 
-        for (unsigned i = 0; i < self->nhandles; i++) {
+        unsigned i;
+        for (i = 0; i < self->nhandles; i++) {
             if (self->handles[i] == h) {
                 memmove(&self->handles[i], &self->handles[i+1], sizeof(HANDLE) * (self->nhandles - i - 1));
                 self->nhandles--;

--- a/src/hal/ethernet/win32/ethernet_win32.c
+++ b/src/hal/ethernet/win32/ethernet_win32.c
@@ -47,11 +47,18 @@
 
 #define HAVE_REMOTE
 
+// Enable WinPcap specific extension: pcap_getevent()
+#define WPCAP
 #include "pcap.h"
 
 struct sEthernetSocket {
     pcap_t* rawSocket;
     struct bpf_program etherTypeFilter;
+};
+
+struct sEthernetHandleSet {
+    HANDLE *handles;
+    int nhandles;
 };
 
 #ifdef __GNUC__ /* detect MINGW */
@@ -90,7 +97,6 @@ typedef ULONG (WINAPI* pgetadaptersaddresses)(ULONG family, ULONG flags, PVOID r
 
 static pgetadaptersaddresses GetAdaptersAddresses;
 
-
 static bool dllLoaded = false;
 
 static void
@@ -114,6 +120,54 @@ loadDLLs(void)
 #endif /* __MINGW64_VERSION_MAJOR */
 
 #endif /* __GNUC__ */
+
+EthernetHandleSet
+EthernetHandleSet_new(void)
+{
+    EthernetHandleSet result = (EthernetHandleSet) GLOBAL_MALLOC(sizeof(struct sEthernetHandleSet));
+
+    if (result != NULL) {
+        result->handles = NULL;
+        result->nhandles = 0;
+    }
+
+    return result;
+}
+
+void
+EthernetHandleSet_addSocket(EthernetHandleSet self, const EthernetSocket sock)
+{
+    if (self != NULL && sock != NULL) {
+        int i = self->nhandles++;
+        self->handles = (HANDLE *) realloc(self->handles, self->nhandles * sizeof(HANDLE));
+            
+        self->handles[i] = pcap_getevent(sock->rawSocket);
+    }
+}
+
+int
+EthernetHandleSet_waitReady(EthernetHandleSet self, unsigned int timeoutMs)
+{
+    int result;
+
+    if ((self != NULL) && (self->nhandles > 0)) {
+        result = WaitForMultipleObjects(self->nhandles, self->handles, 0, timeoutMs);
+    }
+    else {
+       result = -1;
+    }
+
+    return result;
+}
+
+void
+EthernetHandleSet_destroy(EthernetHandleSet self)
+{
+    if (self->handles)
+        free(self->handles);
+
+    GLOBAL_FREEMEM(self);
+}
 
 static char*
 getInterfaceName(int interfaceIndex)
@@ -214,8 +268,6 @@ getAdapterMacAddress(char* pcapAdapterName, uint8_t* macAddress)
         printf("Error getting device addresses!\n");
     }
 }
-
-
 
 void
 Ethernet_getInterfaceMACAddress(const char* interfaceId, uint8_t* addr)
@@ -336,6 +388,28 @@ bool
 Ethernet_isSupported()
 {
     return false;
+}
+
+EthernetHandleSet
+EthernetHandleSet_new(void)
+{
+    return NULL;
+}
+
+void
+EthernetHandleSet_addSocket(EthernetHandleSet self, const EthernetSocket sock)
+{
+}
+
+int
+EthernetHandleSet_waitReady(EthernetHandleSet self, unsigned int timeoutMs)
+{
+    return 0;
+}
+
+void
+EthernetHandleSet_destroy(EthernetHandleSet self)
+{
 }
 
 void

--- a/src/hal/inc/hal_ethernet.h
+++ b/src/hal/inc/hal_ethernet.h
@@ -69,6 +69,15 @@ void
 EthernetHandleSet_addSocket(EthernetHandleSet self, const EthernetSocket sock);
 
 /**
+ * \brief remove a socket from an existing handle set
+ *
+ * \param self the HandleSet instance
+ * \param sock the socket to add
+ */
+void
+EthernetHandleSet_removeSocket(EthernetHandleSet self, const EthernetSocket sock);
+
+/**
  * \brief wait for a socket to become ready
  *
  * This function is corresponding to the BSD socket select function.

--- a/src/hal/inc/hal_ethernet.h
+++ b/src/hal/inc/hal_ethernet.h
@@ -68,18 +68,17 @@ EthernetHandleSet_new(void);
 void
 EthernetHandleSet_addSocket(EthernetHandleSet self, const EthernetSocket sock);
 
-
 /**
  * \brief wait for a socket to become ready
  *
  * This function is corresponding to the BSD socket select function.
- * It returns the number of sockets on which data is pending or 0 if no data is pending
- * on any of the monitored connections. The function will return after "timeout" ms if no
- * data is pending.
- * The function shall return -1 if a socket error occures.
+ * The function will return after \p timeoutMs ms if no data is pending.
  *
- *  \param self the EthernetHandleSet instance
- *  \param timeout in milliseconds (ms)
+ * \param self the HandleSet instance
+ * \param timeout in milliseconds (ms)
+ * \return It returns the number of sockets on which data is pending
+ *   or 0 if no data is pending on any of the monitored connections.
+ *   The function shall return -1 if a socket error occures.
  */
 int
 EthernetHandleSet_waitReady(EthernetHandleSet self, unsigned int timeoutMs);

--- a/src/hal/inc/hal_ethernet.h
+++ b/src/hal/inc/hal_ethernet.h
@@ -48,6 +48,50 @@ extern "C" {
  */
 typedef struct sEthernetSocket* EthernetSocket;
 
+/** Opaque reference for a set of ethernet socket handles */
+typedef struct sEthernetHandleSet* EthernetHandleSet;
+
+/**
+ * \brief Create a new connection handle set (EthernetHandleSet)
+ *
+ * \return new EthernetHandleSet instance
+ */
+EthernetHandleSet
+EthernetHandleSet_new(void);
+
+/**
+ * \brief add a socket to an existing handle set
+ *
+ * \param self the HandleSet instance
+ * \param sock the socket to add
+ */
+void
+EthernetHandleSet_addSocket(EthernetHandleSet self, const EthernetSocket sock);
+
+
+/**
+ * \brief wait for a socket to become ready
+ *
+ * This function is corresponding to the BSD socket select function.
+ * It returns the number of sockets on which data is pending or 0 if no data is pending
+ * on any of the monitored connections. The function will return after "timeout" ms if no
+ * data is pending.
+ * The function shall return -1 if a socket error occures.
+ *
+ *  \param self the EthernetHandleSet instance
+ *  \param timeout in milliseconds (ms)
+ */
+int
+EthernetHandleSet_waitReady(EthernetHandleSet self, unsigned int timeoutMs);
+
+/**
+ * \brief destroy the EthernetHandleSet instance
+ *
+ * \param self the HandleSet instance to destroy
+ */
+void
+EthernetHandleSet_destroy(EthernetHandleSet self);
+
 /**
  * \brief Return the MAC address of an Ethernet interface.
  *

--- a/src/hal/inc/hal_socket.h
+++ b/src/hal/inc/hal_socket.h
@@ -63,7 +63,7 @@ HandleSet
 Handleset_new(void);
 
 /**
- * \brief add a soecket to an existing handle set
+ * \brief add a socket to an existing handle set
  *
  * \param self the HandleSet instance
  * \param sock the socket to add

--- a/src/hal/inc/hal_socket.h
+++ b/src/hal/inc/hal_socket.h
@@ -71,18 +71,17 @@ Handleset_new(void);
 void
 Handleset_addSocket(HandleSet self, const Socket sock);
 
-
 /**
  * \brief wait for a socket to become ready
  *
  * This function is corresponding to the BSD socket select function.
- * It returns the number of sockets on which data is pending or 0 if no data is pending
- * on any of the monitored connections. The function will return after "timeout" ms if no
- * data is pending.
- * The function shall return -1 if a socket error occures.
+ * The function will return after \p timeoutMs ms if no data is pending.
  *
- *  \param self the HandleSet instance
- *  \param timeout in milliseconds (ms)
+ * \param self the HandleSet instance
+ * \param timeout in milliseconds (ms)
+ * \return It returns the number of sockets on which data is pending
+ *   or 0 if no data is pending on any of the monitored connections.
+ *   The function shall return -1 if a socket error occures.
  */
 int
 Handleset_waitReady(HandleSet self, unsigned int timeoutMs);

--- a/src/sampled_values/sv_subscriber.c
+++ b/src/sampled_values/sv_subscriber.c
@@ -229,6 +229,11 @@ SVReceiver_stopThreadless(SVReceiver self)
     self->running = false;
 }
 
+void
+SVReceiver_addHandleSet(SVReceiver self, EthernetHandleSet handles)
+{
+    return EthernetHandleSet_addSocket(handles, self->ethSocket);
+}
 
 static void
 parseASDU(SVReceiver self, SVSubscriber subscriber, uint8_t* buffer, int length)

--- a/src/sampled_values/sv_subscriber.h
+++ b/src/sampled_values/sv_subscriber.h
@@ -213,6 +213,20 @@ SVReceiver_stopThreadless(SVReceiver self);
 bool
 SVReceiver_tick(SVReceiver self);
 
+/* Forward declaration */
+typedef struct sEthernetHandleSet* EthernetHandleSet;
+
+/**
+ * \brief Add the receiver to a handleset for multiplexed asynchronous IO.
+ *
+ * Note: This function must only be called after SVReceiver_startThreadless().
+ *
+ * \param[in] self The SVReceiver instance.
+ * \param[inout] handles The EthernetHandleSet to which the EthernetSocket of this receiver should be added.
+ */
+void
+SVReceiver_addHandleSet(SVReceiver self, EthernetHandleSet handles);
+
 /*
  * Subscriber
  */

--- a/src/sampled_values/sv_subscriber.h
+++ b/src/sampled_values/sv_subscriber.h
@@ -210,6 +210,15 @@ SVReceiver_startThreadless(SVReceiver self);
 void
 SVReceiver_stopThreadless(SVReceiver self);
 
+/**
+ * \brief Parse SV messages if they are available.
+ *
+ * Call after reception of ethernet frame and periodically to to house keeping tasks
+ *
+ * \param self the receiver object
+ *
+ * \return true if a message was available and has been parsed, false otherwise
+ */
 bool
 SVReceiver_tick(SVReceiver self);
 


### PR DESCRIPTION
This PR adds a new EthernetHandleSet interface and implementations for Windows, BSD and Linux.
This allows us to asynchronously wait on many SV and GOOSE subscribers.

It is functionally equivalent to the existing HandleSet interface from `hal_socket.h`.

Both the SV and GOOSE subscriber have been extended to support this new interface.