### PR TITLE
correcting version detection for swig

### DIFF
--- a/pyiec61850/CMakeLists.txt
+++ b/pyiec61850/CMakeLists.txt
@@ -15,8 +15,7 @@ if(WIN32)
 else()
     set(LIBS iec61850-shared)
 endif()
-
-if(${SWIG_VERSION} VERSION_LESS 3.0)
+if(${CMAKE_VERSION} VERSION_LESS 3.8)
     swig_add_module(iec61850 python iec61850.i)
 else()
     swig_add_library(iec61850


### PR DESCRIPTION
Hi

There was a issue with swig about using swig_add_module or swig_add_library: it depends on cmake version not on swig version.

Regards