### PR TITLE
Fix typo in python install path detection

### DIFF
--- a/pyiec61850/CMakeLists.txt
+++ b/pyiec61850/CMakeLists.txt
@@ -34,7 +34,7 @@ swig_link_libraries(iec61850 ${PYTHON_LIBRARIES} ${LIBS})
 # Finding python modules install path
 execute_process(
 	COMMAND ${PYTHON_EXECUTABLE} -c
-	"from distutils.sysconfig import get_python_lib; import.sys; sys.stdout.write(get_python_lib())"
+	"from distutils.sysconfig import get_python_lib; import sys; sys.stdout.write(get_python_lib())"
 	OUTPUT_VARIABLE PYTHON_SITE_DIR
 )
 


### PR DESCRIPTION
Without this fix, cmake -DBUILD_PYTHON_BINDINGS=ON fails.