### PR TITLE
sv-publisher: fix invalid calculation of the total packet length 

### DIFF
--- a/src/sampled_values/sv_publisher.c
+++ b/src/sampled_values/sv_publisher.c
@@ -367,7 +367,15 @@ SVPublisher_ASDU_getEncodedSize(SVPublisher_ASDU self)
         encodedSize += 4;
 
     /* sample */
-    encodedSize += 2;
+    if (self->dataSize < 128)
+        encodedSize += 2;
+    else if (self->dataSize < 256)
+        encodedSize += 3;
+    else if (self->dataSize < 65535)
+        encodedSize += 4;
+    else
+        encodedSize += 5;
+
     encodedSize += self->dataSize;
 
     /* smpMod */

--- a/src/sampled_values/sv_publisher.c
+++ b/src/sampled_values/sv_publisher.c
@@ -367,15 +367,7 @@ SVPublisher_ASDU_getEncodedSize(SVPublisher_ASDU self)
         encodedSize += 4;
 
     /* sample */
-    if (self->dataSize < 128)
-        encodedSize += 2;
-    else if (self->dataSize < 256)
-        encodedSize += 3;
-    else if (self->dataSize < 65535)
-        encodedSize += 4;
-    else
-        encodedSize += 5;
-
+    encodedSize += (1 + BerEncoder_determineLengthSize(self->dataSize));
     encodedSize += self->dataSize;
 
     /* smpMod */


### PR DESCRIPTION
The BER length field is not always encoded with a single byte. For lengths >= 128 byte, the BER length field uses multiple bytes. Therefore the calculation of the total packet size if invalid and causes the SV publisher to send corrupted packets.