### PR TITLE
- MMS server: fixed possible crash when client disconnects during fil…

### DIFF
--- a/src/mms/inc_private/mms_server_internal.h
+++ b/src/mms/inc_private/mms_server_internal.h
@@ -85,6 +85,8 @@
 #define MMS_FILE_UPLOAD_STATE_SEND_OBTAIN_FILE_ERROR_DESTINATION 9
 #define MMS_FILE_UPLOAD_STATE_SEND_OBTAIN_FILE_RESPONSE 10
 
+#define MMS_FILE_UPLOAD_STATE_INTERRUPTED 11
+
 typedef struct sMmsObtainFileTask* MmsObtainFileTask;
 
 struct sMmsObtainFileTask {


### PR DESCRIPTION
…e upload

Sometimes the file upload was unsuccessful and our client implementation disconnected immediately. Sometimes this caused the server to crash and I found that the file handle was used not in a thread-safe way. Looking forward to your comments!