### PR TITLE
TimeActivatedControl before wait check and fixes for file-upload issues.

### DIFF
--- a/src/iec61850/inc/iec61850_server.h
+++ b/src/iec61850/inc/iec61850_server.h
@@ -1195,6 +1195,16 @@ LIB61850_API DataObject*
 ControlAction_getControlObject(ControlAction self);
 
 /**
+ * \brief Gets the time of the control, if it's a timeActivatedControl, returns 0, if it's not.
+ *
+ * \param self the control action instance
+ *
+ * \return the controllable data object instance
+ */
+LIB61850_API uint64_t
+ControlAction_getControlTime(ControlAction self);
+
+/**
  * \brief Control model callback to perform the static tests (optional).
  *
  * NOTE: Signature changed in version 1.4!

--- a/src/iec61850/server/mms_mapping/control.c
+++ b/src/iec61850/server/mms_mapping/control.c
@@ -1777,5 +1777,13 @@ ControlAction_getControlObject(ControlAction self)
     return controlObject->dataObject;
 }
 
+uint64_t
+ControlAction_getControlTime(ControlAction self)
+{
+    ControlObject* controlObject = (ControlObject*) self;
+
+    return controlObject->operateTime;
+}
+
 #endif /* (CONFIG_IEC61850_CONTROL_SERVICE == 1) */
 

--- a/src/iec61850/server/mms_mapping/control.c
+++ b/src/iec61850/server/mms_mapping/control.c
@@ -1581,15 +1581,31 @@ Control_writeAccessControlObject(MmsMapping* self, MmsDomain* domain, char* vari
                     controlObject->interlockCheck = interlockCheck;
                     controlObject->mmsConnection = connection;
 
-                    initiateControlTask(controlObject);
+                    CheckHandlerResult checkResult = CONTROL_ACCEPTED;
+                    if (controlObject->checkHandler != NULL) { /* perform operative tests */
 
-                    setState(controlObject, STATE_WAIT_FOR_ACTIVATION_TIME);
+                        checkResult = controlObject->checkHandler((ControlAction) controlObject,
+                            controlObject->checkHandlerParameter, ctlVal, testCondition, interlockCheck);
 
-                    if (DEBUG_IED_SERVER)
-                        printf("Oper: activate time activated control\n");
+                    }
 
-                    indication = DATA_ACCESS_ERROR_SUCCESS;
+                    if(checkResult == CONTROL_ACCEPTED){
+                        initiateControlTask(controlObject);
+
+                        setState(controlObject, STATE_WAIT_FOR_ACTIVATION_TIME);
+
+                        if (DEBUG_IED_SERVER)
+                            printf("Oper: activate time activated control\n");
+
+                        indication = DATA_ACCESS_ERROR_SUCCESS;
+                    }
+                    else{
+                        indication = (MmsDataAccessError) checkResult;
+                    }
                 }
+            }
+            else{
+                controlObject->operateTime = 0;
             }
 
             MmsValue_update(controlObject->oper, value);
@@ -1681,7 +1697,6 @@ Control_writeAccessControlObject(MmsMapping* self, MmsDomain* domain, char* vari
         if (controlObject->timeActivatedOperate) {
             controlObject->timeActivatedOperate = false;
             abortControlOperation(controlObject);
-            indication = DATA_ACCESS_ERROR_SUCCESS;
             goto free_and_return;
         }
     }

--- a/src/mms/iso_mms/client/mms_client_files.c
+++ b/src/mms/iso_mms/client/mms_client_files.c
@@ -210,8 +210,10 @@ mmsClient_handleFileCloseRequest(
         if (frsm->obtainRequest)
             frsm->obtainRequest->timeout = Hal_getTimeInMs() + connection->requestTimeout;
 
-        FileSystem_closeFile(frsm->fileHandle);
-        frsm->fileHandle = NULL;
+        if(frsm->fileHandle){
+            FileSystem_closeFile(frsm->fileHandle);
+            frsm->fileHandle = NULL;
+        }
         frsm->frsmId = 0;
         frsm->obtainRequest = NULL;
 

--- a/src/mms/iso_mms/server/mms_server_connection.c
+++ b/src/mms/iso_mms/server/mms_server_connection.c
@@ -554,20 +554,25 @@ handleConfirmedResponsePdu(
 
                         bool moreFollows;
 
-                        if (mmsMsg_parseFileReadResponse(buffer, startBufPos, maxBufPos, invokeId, fileTask->frmsId, &moreFollows, mmsFileReadHandler, (void*) fileTask)) {
+                        if(fileTask->fileHandle == NULL){
+                            fileTask->state = MMS_FILE_UPLOAD_STATE_SEND_OBTAIN_FILE_ERROR_DESTINATION;
+                        }
+                        else{
+                            if (mmsMsg_parseFileReadResponse(buffer, startBufPos, maxBufPos, invokeId, fileTask->frmsId, &moreFollows, mmsFileReadHandler, (void*) fileTask)) {
 
-                            if (moreFollows) {
-                                fileTask->state = MMS_FILE_UPLOAD_STATE_SEND_FILE_READ;
+                                if (moreFollows) {
+                                    fileTask->state = MMS_FILE_UPLOAD_STATE_SEND_FILE_READ;
+                                }
+                                else {
+                                    fileTask->state = MMS_FILE_UPLOAD_STATE_SEND_FILE_CLOSE;
+                                }
                             }
                             else {
-                                fileTask->state = MMS_FILE_UPLOAD_STATE_SEND_FILE_CLOSE;
-                            }
-                        }
-                        else {
-                            fileTask->state = MMS_FILE_UPLOAD_STATE_SEND_OBTAIN_FILE_ERROR_SOURCE;
+                                fileTask->state = MMS_FILE_UPLOAD_STATE_SEND_OBTAIN_FILE_ERROR_SOURCE;
 
-                            if (DEBUG_MMS_SERVER)
-                                printf("MMS_SERVER: error parsing file-read-response\n");
+                                if (DEBUG_MMS_SERVER)
+                                    printf("MMS_SERVER: error parsing file-read-response\n");
+                            }
                         }
                     }
                     else {
@@ -588,7 +593,9 @@ handleConfirmedResponsePdu(
                     MmsObtainFileTask fileTask = getUploadTaskByInvokeId(self->server, invokeId);
 
                     if (fileTask != NULL) {
-                        FileSystem_closeFile(fileTask->fileHandle);
+                        if(fileTask->fileHandle){
+                            FileSystem_closeFile(fileTask->fileHandle);
+                        }
                         fileTask->state = MMS_FILE_UPLOAD_STATE_SEND_OBTAIN_FILE_RESPONSE;
                     }
                     else {

--- a/src/mms/iso_mms/server/mms_server_connection.c
+++ b/src/mms/iso_mms/server/mms_server_connection.c
@@ -464,8 +464,13 @@ mmsFileReadHandler(uint32_t invokeId, void* parameter, MmsError mmsError, int32_
     if (mmsError == MMS_ERROR_NONE) {
         if (DEBUG_MMS_SERVER)
             printf("MMS_SERVER:  file %i received %i bytes\n", task->frmsId, bytesReceived);
-
-        FileSystem_writeFile(task->fileHandle, buffer, bytesReceived);
+            if(task->fileHandle){
+                FileSystem_writeFile(task->fileHandle, buffer, bytesReceived);
+            }
+            else{
+                if (DEBUG_MMS_SERVER)
+                    printf("MMS_SERVER: problem reading file %i file already closed\n", task->frmsId);
+            }
     }
     else {
         if (DEBUG_MMS_SERVER)


### PR DESCRIPTION
Added check opportunity before a TimeActivatedControl starts the waiting and a getter for the time of the control.
The state of the file-upload task was written outside of the mutex-lock, and that caused unexpected errors during file-upload.
Using NULL checks for all the file-closes.