### PR TITLE
Don't delete the child value from managed code

### DIFF
--- a/dotnet/IEC61850forCSharp/MmsValue.cs
+++ b/dotnet/IEC61850forCSharp/MmsValue.cs
@@ -547,12 +547,13 @@ namespace IEC61850
 				if ((elementType == MmsType.MMS_ARRAY) || (elementType == MmsType.MMS_STRUCTURE)) {
 				
 					if ((index >= 0) && (index < Size ())) {
-                        if (elementValue != null)
-						    MmsValue_setElement (valueReference, index, elementValue.valueReference);
-                        else
-                            MmsValue_setElement (valueReference, index, IntPtr.Zero);
+						if (elementValue != null) {
+							elementValue.responsableForDeletion = false;
+							MmsValue_setElement (valueReference, index, elementValue.valueReference);
+						} else
+							MmsValue_setElement (valueReference, index, IntPtr.Zero);
 
-                    } else
+                    			} else
 						throw new MmsValueException ("Index out of bounds");
 				
 				} else


### PR DESCRIPTION
When an element is added as a child element, the child should never delete itself as the parent will do that from native code.