### PR TITLE
Add generated stack_config.h to installed headers list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ set(API_HEADERS
     src/sampled_values/sv_subscriber.h
     src/sampled_values/sv_publisher.h
     src/logging/logging_api.h
+    ${CMAKE_CURRENT_BINARY_DIR}/config/stack_config.h
 )
 
 if(MSVC AND MSVC_VERSION LESS 1800)


### PR DESCRIPTION
File `stack_config.h` needs to be installed because file
/usr/include/libiec61850/libiec61850_platform_includes.h
includes it.

This fixes https://github.com/mz-automation/libiec61850/issues/214