### PR TITLE
SV and Goose publisher: remove libiec61850_platform_includes.h include

### DIFF
--- a/src/goose/goose_publisher.h
+++ b/src/goose/goose_publisher.h
@@ -24,7 +24,6 @@
 #ifndef GOOSE_PUBLISHER_H_
 #define GOOSE_PUBLISHER_H_
 
-#include "libiec61850_platform_includes.h"
 #include "linked_list.h"
 #include "mms_value.h"
 

--- a/src/sampled_values/sv_publisher.h
+++ b/src/sampled_values/sv_publisher.h
@@ -25,7 +25,6 @@
 #ifndef LIBIEC61850_SRC_SAMPLED_VALUES_SV_PUBLISHER_H_
 #define LIBIEC61850_SRC_SAMPLED_VALUES_SV_PUBLISHER_H_
 
-#include "libiec61850_platform_includes.h"
 #include "iec61850_common.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
Any application including goose_publisher.h or sv_publisher.h from installed headers
(/usr/include/libiec61850) fail to build due to missing libiec61850_platform_includes.h
internal header.

libiec61850_platform_includes.h was removed from installed headers (API_HEADERS)
by commit [1].

[1] 7d22aba90086d5f498a9c3bf0f888fbf60b5b08f

Reported-by: Jean-Baptiste FLAMANT <jean-baptiste.flamant@smile.fr>
Signed-off-by: Romain Naour <romain.naour@smile.fr>