### PR TITLE
Fix const conversion in client_example_async.

### DIFF
--- a/examples/iec61850_client_example_async/client_example_async.c
+++ b/examples/iec61850_client_example_async/client_example_async.c
@@ -232,20 +232,22 @@ int main(int argc, char** argv) {
 
             Thread_sleep(1000);
 
-
-            IedConnection_readObjectAsync(con, &error, "simpleIOGenericIO/GGIO1.AnIn1.mag.f", IEC61850_FC_MX, readObjectHandler, "simpleIOGenericIO/GGIO1.AnIn1.mag.f");
-
-            if (error != IED_ERROR_OK) {
-                printf("read object error %i\n", error);
-            }
-
-            IedConnection_readObjectAsync(con, &error, "simpleIOGenericIO/GGIO1.AnIn2.mag.f", IEC61850_FC_MX, readObjectHandler, "simpleIOGenericIO/GGIO1.AnIn2.mag.f");
+            char *anin1_mag_f = "simpleIOGenericIO/GGIO1.AnIn1.mag.f";
+            IedConnection_readObjectAsync(con, &error, "simpleIOGenericIO/GGIO1.AnIn1.mag.f", IEC61850_FC_MX, readObjectHandler, anin1_mag_f);
 
             if (error != IED_ERROR_OK) {
                 printf("read object error %i\n", error);
             }
 
-            IedConnection_getVariableSpecificationAsync(con, &error, "simpleIOGenericIO/GGIO1.AnIn1", IEC61850_FC_MX, getVarSpecHandler, "simpleIOGenericIO/GGIO1.AnIn1");
+            char *anin2_mag_f = "simpleIOGenericIO/GGIO1.AnIn2.mag.f";
+            IedConnection_readObjectAsync(con, &error, "simpleIOGenericIO/GGIO1.AnIn2.mag.f", IEC61850_FC_MX, readObjectHandler, anin2_mag_f);
+
+            if (error != IED_ERROR_OK) {
+                printf("read object error %i\n", error);
+            }
+
+            char *anin1 = "simpleIOGenericIO/GGIO1.AnIn1";
+            IedConnection_getVariableSpecificationAsync(con, &error, "simpleIOGenericIO/GGIO1.AnIn1", IEC61850_FC_MX, getVarSpecHandler, anin1);
 
             if (error != IED_ERROR_OK) {
                 printf("get variable specification error %i\n", error);


### PR DESCRIPTION
Note: This does not improve the underlying library.

Ideally the function should probably accept a const, but modifying the library seems like a large change to make.

If this is not the correct destination branch, please edit that for me or let me know what one to use.