### PR TITLE
Fix typo for tls_client_example.c file comment

### DIFF
--- a/examples/tls_client_example/tls_client_example.c
+++ b/examples/tls_client_example/tls_client_example.c
@@ -1,5 +1,5 @@
 /*
- * tls_client_exmaple.c
+ * tls_client_example.c
  *
  * This example shows how to configure TLS
  */


### PR DESCRIPTION
As title.