### PR TITLE
Mbourhis/python swig event handler for command termination

### DIFF
--- a/pyiec61850/eventHandlers/commandTermHandler.hpp
+++ b/pyiec61850/eventHandlers/commandTermHandler.hpp
@@ -26,8 +26,21 @@ class CommandTermHandler: public EventHandler {
  */
 class CommandTermSubscriber: public EventSubscriber {
     public:
+        CommandTermSubscriber(): EventSubscriber()
+        {
+            m_libiec61850_control_object_client = nullptr;
+        }
 
-        virtual void subscribe() {
+        virtual ~CommandTermSubscriber() {}
+
+        virtual void subscribe()
+        {
+            // preconditions
+            if (nullptr == m_libiec61850_control_object_client) {
+                fprintf(stderr, "CommandTermSubscriber::subscribe() failed: 'control object client' is null\n");
+                return;
+            }
+
             // install the libiec61850 callback:
             // the 'function pointer' is the 'static' method of this class
             ControlObjectClient_setCommandTerminationHandler(
@@ -41,6 +54,12 @@ class CommandTermSubscriber: public EventSubscriber {
         {
             PyThreadStateLock PyThreadLock;
 
+            // Preconditions
+            if (nullptr == connection) {
+                fprintf(stderr, "CommandTermSubscriber::triggerCommandTermHandler() failed: input object is null\n");
+                return;
+            }
+
             // TODO: search the appropriate 'EventSubscriber' object
             if (m_last_created_event_subscriber) {
                 EventHandler *l_event_handler_p = m_last_created_event_subscriber->getEventHandler();
@@ -49,8 +68,11 @@ class CommandTermSubscriber: public EventSubscriber {
                     l_event_handler_p->trigger();
                 }
                 else {
-                    printf("The EventHandler is undefined\n");
+                    fprintf(stderr, "CommandTermSubscriber::triggerCommandTermHandler() failed: EventHandler is undefined\n");
                 }
+            }
+            else {
+                fprintf(stderr, "CommandTermSubscriber::triggerCommandTermHandler() failed: subscriber is not registered\n");
             }
         }
 

--- a/pyiec61850/eventHandlers/commandTermHandler.hpp
+++ b/pyiec61850/eventHandlers/commandTermHandler.hpp
@@ -1,0 +1,68 @@
+#ifndef PYIEC61850_COMMANDTERMHANDLER_HPP
+#define PYIEC61850_COMMANDTERMHANDLER_HPP
+
+#include "eventHandler.hpp"
+
+/*
+ *  Abstract class for processing the received 'Command Termination' events.
+ */
+class CommandTermHandler: public EventHandler {
+    public:
+        virtual ~CommandTermHandler() {}
+
+        virtual void setReceivedData(void *i_data_p)
+        {
+            // copy the received data
+            ControlObjectClient *l_my_data_p = static_cast<ControlObjectClient*>(i_data_p);
+            _libiec61850_control_object_client = *l_my_data_p;
+        }
+
+        ControlObjectClient  _libiec61850_control_object_client;
+};
+
+
+/*
+ *  Class for the subscription to the 'Command Termination' events
+ */
+class CommandTermSubscriber: public EventSubscriber {
+    public:
+
+        virtual void subscribe() {
+            // install the libiec61850 callback:
+            // the 'function pointer' is the 'static' method of this class
+            ControlObjectClient_setCommandTerminationHandler(
+                                m_libiec61850_control_object_client,
+                                CommandTermSubscriber::triggerCommandTermHandler,
+                                NULL);
+        }
+
+        // Static method: it is the 'callback' for libiec61850 in C
+        static void triggerCommandTermHandler(void *parameter, ControlObjectClient connection)
+        {
+            PyThreadStateLock PyThreadLock;
+
+            // TODO: search the appropriate 'EventSubscriber' object
+            if (m_last_created_event_subscriber) {
+                EventHandler *l_event_handler_p = m_last_created_event_subscriber->getEventHandler();
+                if (l_event_handler_p) {
+                    l_event_handler_p->setReceivedData(&connection);
+                    l_event_handler_p->trigger();
+                }
+                else {
+                    printf("The EventHandler is undefined\n");
+                }
+            }
+        }
+
+        // Setters
+        void setLibiec61850ControlObjectClient(const ControlObjectClient &i_libiec61850_control_object_client)
+        {
+            m_libiec61850_control_object_client = i_libiec61850_control_object_client;
+        }
+
+    protected:
+        // Parameters
+        ControlObjectClient m_libiec61850_control_object_client;
+};
+
+#endif

--- a/pyiec61850/eventHandlers/gooseHandler.hpp
+++ b/pyiec61850/eventHandlers/gooseHandler.hpp
@@ -22,8 +22,22 @@ class GooseHandler: public EventHandler {
 
 class GooseSubscriberForPython: public EventSubscriber {
     public:
+        GooseSubscriberForPython(): EventSubscriber()
+        {
+            m_libiec61850_goose_subscriber = nullptr;
+        }
 
-        virtual void subscribe() {
+        virtual ~GooseSubscriberForPython() {}
+
+
+        virtual void subscribe()
+        {
+            // preconditions
+            if (nullptr == m_libiec61850_goose_subscriber) {
+                fprintf(stderr, "GooseSubscriberForPython::subscribe() failed: 'GOOSE subscriber' is null\n");
+                return;
+            }
+
             // install the libiec61850 callback:
             // the 'function pointer' is the 'static' method of this class
             GooseSubscriber_setListener(m_libiec61850_goose_subscriber,
@@ -36,6 +50,12 @@ class GooseSubscriberForPython: public EventSubscriber {
         {
             PyThreadStateLock PyThreadLock;
 
+            // Preconditions
+            if (nullptr == subscriber) {
+                fprintf(stderr, "GooseSubscriberForPython::triggerGooseHandler() failed: input object is null\n");
+                return;
+            }
+
             // TODO: search the appropriate 'EventSubscriber' object
             if (m_last_created_event_subscriber) {
                 EventHandler *l_event_handler_p = m_last_created_event_subscriber->getEventHandler();
@@ -44,8 +64,11 @@ class GooseSubscriberForPython: public EventSubscriber {
                     l_event_handler_p->trigger();
                 }
                 else {
-                    printf("The EventHandler is undefined\n");
+                    fprintf(stderr, "GooseSubscriberForPython::triggerGooseHandler() failed: EventHandler is undefined\n");
                 }
+            }
+            else {
+                fprintf(stderr, "GooseSubscriberForPython::triggerGooseHandler() failed: subscriber is not registered\n");
             }
         }
 

--- a/pyiec61850/eventHandlers/reportControlBlockHandler.hpp
+++ b/pyiec61850/eventHandlers/reportControlBlockHandler.hpp
@@ -22,8 +22,21 @@ class RCBHandler: public EventHandler {
 
 class RCBSubscriber: public EventSubscriber {
     public:
+        RCBSubscriber(): EventSubscriber()
+        {
+            m_ied_connection = nullptr;
+        }
+
+        virtual ~RCBSubscriber() {}
+
 
         virtual void subscribe() {
+            // preconditions
+            if (nullptr == m_ied_connection) {
+                fprintf(stderr, "RCBSubscriber::subscribe() failed: 'IedConnection' is null\n");
+                return;
+            }
+
             // install the libiec61850 callback:
             // the 'function pointer' is the 'static' method of this class
             IedConnection_installReportHandler(m_ied_connection,
@@ -38,6 +51,12 @@ class RCBSubscriber: public EventSubscriber {
         {
             PyThreadStateLock PyThreadLock;
 
+            // Preconditions
+            if (nullptr == report) {
+                fprintf(stderr, "RCBSubscriber::triggerRCBHandler() failed: input object is null\n");
+                return;
+            }
+
             // TODO: search the appropriate 'EventSubscriber' object
             if (m_last_created_event_subscriber) {
                 EventHandler *l_event_handler_p = m_last_created_event_subscriber->getEventHandler();
@@ -46,8 +65,11 @@ class RCBSubscriber: public EventSubscriber {
                     l_event_handler_p->trigger();
                 }
                 else {
-                    printf("The EventHandler is undefined\n");
+                    fprintf(stderr, "RCBSubscriber::triggerRCBHandler() failed: EventHandler is undefined\n");
                 }
+            }
+            else {
+                fprintf(stderr, "RCBSubscriber::triggerRCBHandler() failed: subscriber is not registered\n");
             }
         }
 

--- a/pyiec61850/iec61850.i
+++ b/pyiec61850/iec61850.i
@@ -104,7 +104,7 @@ void GooseSubscriber_setDstMac(GooseSubscriber subscriber,
 #include "eventHandlers/reportControlBlockHandler.hpp"
 #include "eventHandlers/gooseHandler.hpp"
 #include "eventHandlers/commandTermHandler.hpp"
-EventSubscriber* EventSubscriber::m_last_created_event_subscriber = nullptr;
+std::map< std::string, EventSubscriber*> EventSubscriber::m_subscriber_map = {};
 %}
 %include "eventHandlers/eventHandler.hpp"
 %include "eventHandlers/reportControlBlockHandler.hpp"

--- a/pyiec61850/iec61850.i
+++ b/pyiec61850/iec61850.i
@@ -98,15 +98,18 @@ void GooseSubscriber_setDstMac(GooseSubscriber subscriber,
 /* Event Handler section */
 %feature("director") RCBHandler;
 %feature("director") GooseHandler;
+%feature("director") CommandTermHandler;
 %{
 #include "eventHandlers/eventHandler.hpp"
 #include "eventHandlers/reportControlBlockHandler.hpp"
 #include "eventHandlers/gooseHandler.hpp"
+#include "eventHandlers/commandTermHandler.hpp"
 EventSubscriber* EventSubscriber::m_last_created_event_subscriber = nullptr;
 %}
 %include "eventHandlers/eventHandler.hpp"
 %include "eventHandlers/reportControlBlockHandler.hpp"
 %include "eventHandlers/gooseHandler.hpp"
+%include "eventHandlers/commandTermHandler.hpp"
 
 /* Goose Publisher section */
 %{


### PR DESCRIPTION
Hi,

To continue the 'event' handling for the Swig Python wrapper,
I have added the support for the 'command termination' event.

The underlying mechanism is still the same (as for the GOOSE event and RCB event) [1].

I have also fixed the 'known' limitation ("todo" comments in the code) by considering a set of 'subscribers', active at the same time, not just one.

[1] https://rawgit.com/swig/swig/master/Doc/Manual/SWIGPlus.html#SWIGPlus_target_language_callbacks 

Regards,

Mikael Bourhis