### PR TITLE
Added fuzzer for oss-fuzz integration.

### DIFF
--- a/fuzz/fuzz_mms_decode.c
+++ b/fuzz/fuzz_mms_decode.c
@@ -5,11 +5,11 @@
 #include "hal_thread.h"
 
 int LLVMFuzzerTestOneInput(const char *data, size_t size) {
-	int out;
-	MmsValue* value = NULL;
-	value = MmsValue_decodeMmsData(data, 0, size, &out);
-	if (value != NULL) {
-		free(value);
-	}
-	return 0;
+    int out;
+    MmsValue* value = NULL;
+    value = MmsValue_decodeMmsData(data, 0, size, &out);
+    if (value != NULL) {
+        free(value);
+    }
+    return 0;
 }

--- a/fuzz/fuzz_mms_decode.c
+++ b/fuzz/fuzz_mms_decode.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "iec61850_server.h"
+#include "hal_thread.h"
+
+int LLVMFuzzerTestOneInput(const char *data, size_t size) {
+	int out;
+	MmsValue* value = NULL;
+	value = MmsValue_decodeMmsData(data, 0, size, &out);
+	if (value != NULL) {
+		free(value);
+	}
+	return 0;
+}


### PR DESCRIPTION
Hi Maintainers,

I have worked a bit on setting fuzzing up for libiec61850 by way of OSS-Fuzz. Essentially, OSS-Fuzz is a free service run by Google that performs continuous fuzzing of important open source projects, and it would be great to have libiec61850 integrated. The only expectation of integrating into OSS-Fuzz is that bugs will be fixed. This is not a "hard" requirement in that no one enforces this and the main point is if bugs are not fixed then it is a waste of resources to run the fuzzers, which we would like to avoid.

In this PR https://github.com/google/oss-fuzz/pull/5225 I have done exactly that, namely created the necessary logic from an OSS-Fuzz perspective to integrate libiec61850. If you would like to integrate, could you please provide a set of email(s) that will get access to the data produced by OSS-Fuzz, such as bug reports, coverage reports and more stats. The emails should be linked to a Google account in order to view the detailed reports and notice the emails affiliated with the project will be public in the OSS-Fuzz repo, as they will be part of a configuration file.

At the moment I stored the fuzzers in the Google OSS-Fuzz repository, but we can move them up here to make maintenance easier.