### PR TITLE
Fix: segmentation fault ConfigFileParser_createModelFromConfigFile on…

### DIFF
--- a/src/iec61850/server/model/config_file_parser.c
+++ b/src/iec61850/server/model/config_file_parser.c
@@ -560,7 +560,8 @@ exit_error:
     if (DEBUG_IED_SERVER)
         printf("IED_SERVER: error parsing line %i (indentation level = %i)\n", currentLine, indendation);
 
-    IedModel_destroy(model);
+    if (model != NULL)
+        IedModel_destroy(model);
     return NULL;
 }
 


### PR DESCRIPTION
## Fix 
- Segmentation fault ConfigFileParser_createModelFromConfigFile

## Expected Behaviour:

ConfigFileParser_createModelFromConfigFile is expected to return NULL if the file is invalid.

## Actual Behaviour:

```
==10797== Invalid read of size 4
==10797==    at 0x15C5E2: IedModel_destroy (dynamic_model.c:742)
==10797==    by 0x149599: ConfigFileParser_createModelFromConfigFile (config_file_parser.c:497)
==10797==    by 0x14989D: ConfigFileParser_createModelFromConfigFileEx (config_file_parser.c:104)
==10797==    by 0x1411F5: Server::Server(Context&) (Server.cpp:22)
==10797==    by 0x12C80B: main (main.cpp:46)
==10797==  Address 0x4 is not stack'd, malloc'd or (recently) free'd
==10797== 
==10797== 
==10797== Process terminating with default action of signal 11 (SIGSEGV)
==10797==  Access not within mapped region at address 0x4
==10797==    at 0x15C5E2: IedModel_destroy (dynamic_model.c:742)
==10797==    by 0x149599: ConfigFileParser_createModelFromConfigFile (config_file_parser.c:497)
==10797==    by 0x14989D: ConfigFileParser_createModelFromConfigFileEx (config_file_parser.c:104)
==10797==    by 0x1411F5: Server::Server(Context&) (Server.cpp:22)
==10797==    by 0x12C80B: main (main.cpp:46)
==10797==  If you believe this happened as a result of a stack
==10797==  overflow in your program's main thread (unlikely but
==10797==  possible), you can try to increase the size of the
==10797==  main thread stack using the --main-stacksize= flag.
==10797==  The main thread stack size used in this run was 8388608.
```

## How to Reproduce:

```
$> cat iec61850.cfg       
<auto>
  <manufacturer>Tesla</manufacturer>
  <model>S</model>
  <horsepower>670 to 1,020</horsepower>
  <price>$69,420+</price>
</auto>
```