### PR TITLE
MmsValue_setOctetString input buf is const now

### DIFF
--- a/src/mms/inc/mms_value.h
+++ b/src/mms/inc/mms_value.h
@@ -552,7 +552,7 @@ MmsValue_getBinaryTimeAsUtcMs(const MmsValue* self);
  * \param size the size of the buffer that contains the new value
  */
 LIB61850_API void
-MmsValue_setOctetString(MmsValue* self, uint8_t* buf, int size);
+MmsValue_setOctetString(MmsValue* self, const uint8_t* buf, int size);
 
 /**
  * \brief Returns the size in bytes of an MmsValue object of type MMS_OCTET_STRING.

--- a/src/mms/iso_mms/common/mms_value.c
+++ b/src/mms/iso_mms/common/mms_value.c
@@ -1418,7 +1418,7 @@ MmsValue_newOctetString(int size, int maxSize)
 }
 
 void
-MmsValue_setOctetString(MmsValue* self, uint8_t* buf, int size)
+MmsValue_setOctetString(MmsValue* self, const uint8_t* buf, int size)
 {
     if (size <= self->value.octetString.maxSize) {
         memcpy(self->value.octetString.buf, buf, size);


### PR DESCRIPTION
Input buf to MmsValue_setOctetString should be declared as const uint8_t* buf.