### PR TITLE
examples: cmake: fix build with external tls dynamic library

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(CONFIG_USE_EXTERNAL_MBEDTLS_DYNLIB)
+link_directories(${CONFIG_EXTERNAL_MBEDTLS_DYNLIB_PATH})
+endif()
+
 add_subdirectory(server_example_simple)
 add_subdirectory(server_example_basic_io)
 add_subdirectory(server_example_password_auth)


### PR DESCRIPTION
Release v1.5 introduced the possibility, when building with cmake, to use an externally provided build of mbedtls as a dynamic library.
This is activated by setting `CONFIG_USE_EXTERNAL_MBEDTLS_DYNLIB` and tuning involved paths via `CONFIG_EXTERNAL_MBEDTLS_INCLUDE_PATH` and `CONFIG_EXTERNAL_MBEDTLS_DYNLIB_PATH`.

Building the examples failed when `CONFIG_USE_EXTERNAL_MBEDTLS_DYNLIB` was
enabled with the error below:

```
[...]
Scanning dependencies of target server_example_simple
[ 66%] Building C object examples/server_example_simple/CMakeFiles/server_example_simple.dir/server_example_simple.c.o
[ 68%] Building C object examples/server_example_simple/CMakeFiles/server_example_simple.dir/static_model.c.o
[ 68%] Linking C executable server_example_simple
/usr/bin/ld: cannot find -lmbedcrypto
/usr/bin/ld: cannot find -lmbedx509
/usr/bin/ld: cannot find -lmbedtls
collect2: error: ld returned 1 exit status
make[2]: *** [examples/server_example_simple/CMakeFiles/server_example_simple.dir/build.make:101: examples/server_example_simple/server_example_simple] Error 1
make[1]: *** [CMakeFiles/Makefile2:990: examples/server_example_simple/CMakeFiles/server_example_simple.dir/all] Error 2
make: *** [Makefile:163: all] Error 2
```

This PR address the issue by adding `${CONFIG_EXTERNAL_MBEDTLS_DYNLIB_PATH}` to the libraries path for
the linker when needed.