### PR TITLE
fixed memory leak in setGoID, setGoCbRef and setDataSetRef

### DIFF
--- a/src/goose/goose_publisher.c
+++ b/src/goose/goose_publisher.c
@@ -115,18 +115,28 @@ GoosePublisher_destroy(GoosePublisher self)
 void
 GoosePublisher_setGoID(GoosePublisher self, char* goID)
 {
+    if (self->goID != NULL)
+        GLOBAL_FREEMEM(self->goID);
+
     self->goID = StringUtils_copyString(goID);
 }
 
 void
 GoosePublisher_setGoCbRef(GoosePublisher self, char* goCbRef)
 {
+    if (self->goCBRef != NULL)
+        GLOBAL_FREEMEM(self->goCBRef);
+
     self->goCBRef = StringUtils_copyString(goCbRef);
 }
 
 void
 GoosePublisher_setDataSetRef(GoosePublisher self, char* dataSetRef)
 {
+
+    if (self->dataSetRef != NULL)
+        GLOBAL_FREEMEM(self->dataSetRef);
+
     self->dataSetRef = StringUtils_copyString(dataSetRef);
 }
 


### PR DESCRIPTION
Hello, _StringUtils_copyString_ allocates memory for a new string. The functions: _setGoID_, _setGoCbRef_ and _setDataSetRef_ do not free memory for an existing string. My goal is to build a fuzzer using iec61850. For that, I need to change _setGoID_, _setGoCbRef_ and _setDataSetRef_ very often and fast. This causes a memory overflow. Calling _GoosePublisher_create_ and _GoosePublisher_destroy_ is not an option because it takes too much time. The problem is solved using _GLOBAL_FREEMEM_, if a string already exists. 

Thanks for your work on this project, my work would not be possible without it :)