### PR TITLE
Update ied_connection.c

### DIFF
--- a/src/iec61850/client/ied_connection.c
+++ b/src/iec61850/client/ied_connection.c
@@ -258,10 +258,10 @@ ClientDataSet_create(const char* dataSetReference)
 void
 ClientDataSet_destroy(ClientDataSet self)
 {
-    if (self->dataSetValues != NULL)
-        MmsValue_delete(self->dataSetValues);
+	if (self == NULL)
+		return;
 
-    GLOBAL_FREEMEM(self->dataSetReference);
+	MmsValue_delete(self->dataSetValues);
 
     GLOBAL_FREEMEM(self);
 }


### PR DESCRIPTION
ClientDataSet_destroy didn't check if self is null, checked if self->dataSetValues is null though MmsValue_delete checks it itself, and GLOBAL_FREEMEMed(self->dataSetValues) though MmsValue_delete GLOBAL_FREEMEMs its parameter unless it's null.