### PR TITLE
TLS: update CRL load time also when loading from file

### DIFF
--- a/hal/tls/mbedtls/tls_mbedtls.c
+++ b/hal/tls/mbedtls/tls_mbedtls.c
@@ -465,8 +465,12 @@ TLSConfiguration_addCRLFromFile(TLSConfiguration self, const char* filename)
 {
     int ret =  mbedtls_x509_crl_parse_file(&(self->crl), filename);
 
-    if (ret != 0)
+    if (ret != 0) {
         DEBUG_PRINT("TLS", "mbedtls_x509_crl_parse_file returned %d\n", ret);
+    }
+    else {
+        self->crlUpdated = Hal_getTimeInMs();
+    }
 
     return (ret == 0);
 }


### PR DESCRIPTION
Similarly as done when loading a CRL directly, this allows to have the CA chain recalculated for ongoing connections also when using CRLs from files.