### PR TITLE
tls: fix order of operations to copy peer certificate

### DIFF
--- a/hal/tls/mbedtls/tls_mbedtls.c
+++ b/hal/tls/mbedtls/tls_mbedtls.c
@@ -189,8 +189,8 @@ verifyCertificate (void* parameter, mbedtls_x509_crt *crt, int certificate_depth
                 self->peerCert = (uint8_t*) GLOBAL_MALLOC(crt->raw.len);
 
                 if (self->peerCert) {
-                    memcpy(self->peerCert, crt->raw.p, self->peerCertLength);
                     self->peerCertLength = (int)crt->raw.len;
+                    memcpy(self->peerCert, crt->raw.p, self->peerCertLength);
                 }
 
             }


### PR DESCRIPTION
The memcpy is done before assigning the length, so the length is not set and is therefore either 0 (so no peer certificate will be available) or a random number (that can lead to crashes) making the feature not work.

The MR simply copies first the length that will make the memcpy work.