### PR TITLE
association only with specified values for TSelector, PSelector, and SSelector

### DIFF
--- a/src/mms/iso_cotp/cotp.c
+++ b/src/mms/iso_cotp/cotp.c
@@ -466,9 +466,14 @@ parseOptions(CotpConnection* self, uint8_t* buffer, int bufLen)
             if (optionLen < 5) {
                 self->options.tSelDst.size = optionLen;
 
+                const uint8_t TransportSelectorConstValue[4] = {0,1,0,0};
                 int i;
                 for (i = 0; i < optionLen; i++)
+                {
                     self->options.tSelDst.value[i] = buffer[bufPos++];
+ 				   if(TransportSelectorConstValue[i] != self->options.tSelDst.value[i])
+ 					   return false;
+                }
             }
             else
                 goto cpo_error;

--- a/src/mms/iso_presentation/iso_presentation.c
+++ b/src/mms/iso_presentation/iso_presentation.c
@@ -447,9 +447,14 @@ parseNormalModeParameters(IsoPresentation* self, uint8_t* buffer, int totalLengt
             }
             else {
                 self->calledPresentationSelector.size = len;
+                const uint8_t PresentationSelectorConstValue[16] = {0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0};
                 int i;
                 for (i = 0; i < len; i++)
+                {
                     self->calledPresentationSelector.value[i] = buffer[bufPos + i];
+ 				   if(PresentationSelectorConstValue[i] != self->calledPresentationSelector.value[i])
+ 					   return -1;
+                }
             }
 
             bufPos += len;

--- a/src/mms/iso_session/iso_session.c
+++ b/src/mms/iso_session/iso_session.c
@@ -187,9 +187,14 @@ parseSessionHeaderParameters(IsoSession* session, ByteBuffer* message, int param
             {
                session->calledSessionSelector.size = parameterLength;
 
+               const uint8_t SessionSelectorConstValue[16] = {0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
                int i;
                for (i = 0; i < session->calledSessionSelector.size; i++)
+               {
                    session->calledSessionSelector.value[i] = message->buffer[offset++];
+				   if(SessionSelectorConstValue[i] != session->calledSessionSelector.value[i])
+					   return SESSION_ERROR;
+               }
             }
 
             break;


### PR DESCRIPTION
Hi
I added lines to ensure that clients can create associations only with the specified values for TSelector, PSelector, and SSelector.

According to the UCA Document "Conformance Test Procedures for Server Devices with IEC 61850-8-1 interface", 
mentioned parameters should be as defined within the ICD file. otherwise, the server device should fail the association and send the response- to the client.

also, see:
- Siemens PIXIT files for Multi-Functional Protective Relays(for example this [Link](shorturl.at/mvPQT) section 2.1)
- Easergy PIXIT files for (This [Link ](https://www.se.com/au/en/download/document/P54x_PX_TC/) section 2.1)