### PR TITLE
Examples: add command line parameter for choosing the MMS port in som…

### DIFF
--- a/examples/server_example_basic_io/server_example_basic_io.c
+++ b/examples/server_example_basic_io/server_example_basic_io.c
@@ -100,6 +100,12 @@ rcbEventHandler(void* parameter, ReportControlBlock* rcb, ClientConnection conne
 int
 main(int argc, char** argv)
 {
+    int tcpPort = 102;
+
+    if (argc > 1) {
+        tcpPort = atoi(argv[1]);
+    }
+
     printf("Using libIEC61850 version %s\n", LibIEC61850_getVersionString());
 
     /* Create new server configuration object */
@@ -163,7 +169,7 @@ main(int argc, char** argv)
     IedServer_setWriteAccessPolicy(iedServer, IEC61850_FC_DC, ACCESS_POLICY_ALLOW);
 
     /* MMS server will be instructed to start listening for client connections. */
-    IedServer_start(iedServer, 102);
+    IedServer_start(iedServer, tcpPort);
 
     if (!IedServer_isRunning(iedServer)) {
         printf("Starting server failed (maybe need root permissions or another server is already using the port)! Exit.\n");

--- a/examples/server_example_control/server_example_control.c
+++ b/examples/server_example_control/server_example_control.c
@@ -126,6 +126,11 @@ int
 main(int argc, char** argv)
 {
     iedServer = IedServer_create(&iedModel);
+    int tcpPort = 102;
+
+    if (argc > 1) {
+        tcpPort = atoi(argv[1]);
+    }
 
     IedServer_setControlHandler(iedServer, IEDMODEL_GenericIO_GGIO1_SPCSO1,
             (ControlHandler) controlHandlerForBinaryOutput,
@@ -169,7 +174,7 @@ main(int argc, char** argv)
             IEDMODEL_GenericIO_GGIO1_SPCSO9);
 
     /* MMS server will be instructed to start listening to client connections. */
-    IedServer_start(iedServer, 102);
+    IedServer_start(iedServer, tcpPort);
 
     if (!IedServer_isRunning(iedServer)) {
         printf("Starting server failed! Exit.\n");

--- a/examples/server_example_deadband/server_example_deadband.c
+++ b/examples/server_example_deadband/server_example_deadband.c
@@ -36,6 +36,12 @@ connectionHandler (IedServer self, ClientConnection connection, bool connected, 
 int
 main(int argc, char** argv)
 {
+    int tcpPort = 102;
+
+    if (argc > 1) {
+        tcpPort = atoi(argv[1]);
+    }
+
     printf("Using libIEC61850 version %s\n", LibIEC61850_getVersionString());
 
     /* Create new server configuration object */
@@ -74,7 +80,7 @@ main(int argc, char** argv)
     IedServer_setWriteAccessPolicy(iedServer, IEC61850_FC_CF, ACCESS_POLICY_ALLOW);
 
     /* MMS server will be instructed to start listening for client connections. */
-    IedServer_start(iedServer, 102);
+    IedServer_start(iedServer, tcpPort);
 
     if (!IedServer_isRunning(iedServer)) {
         printf("Starting server failed (maybe need root permissions or another server is already using the port)! Exit.\n");

--- a/examples/server_example_files/server_example_files.c
+++ b/examples/server_example_files/server_example_files.c
@@ -55,6 +55,12 @@ fileAccessHandler (void* parameter, MmsServerConnection connection, MmsFileServi
 int
 main(int argc, char** argv)
 {
+    int tcpPort = 102;
+
+    if (argc > 1) {
+        tcpPort = atoi(argv[1]);
+    }
+
     printf("Using libIEC61850 version %s\n", LibIEC61850_getVersionString());
 
     iedServer = IedServer_create(&iedModel);
@@ -70,7 +76,7 @@ main(int argc, char** argv)
     IedServer_setConnectionIndicationHandler(iedServer, (IedConnectionIndicationHandler) connectionHandler, NULL);
 
     /* MMS server will be instructed to start listening to client connections. */
-    IedServer_start(iedServer, 102);
+    IedServer_start(iedServer, tcpPort);
 
     if (!IedServer_isRunning(iedServer)) {
         printf("Starting server failed! Exit.\n");

--- a/examples/server_example_logging/server_example_logging.c
+++ b/examples/server_example_logging/server_example_logging.c
@@ -118,6 +118,12 @@ entryDataCallback (void* parameter, const char* dataRef, const uint8_t* data, in
 int
 main(int argc, char** argv)
 {
+    int tcpPort = 102;
+
+    if (argc > 1) {
+        tcpPort = atoi(argv[1]);
+    }
+
     printf("Using libIEC61850 version %s\n", LibIEC61850_getVersionString());
 
     iedServer = IedServer_create(&iedModel);
@@ -174,7 +180,7 @@ main(int argc, char** argv)
 
 
     /* MMS server will be instructed to start listening to client connections. */
-    IedServer_start(iedServer, 102);
+    IedServer_start(iedServer, tcpPort);
 
     if (!IedServer_isRunning(iedServer)) {
         printf("Starting server failed! Exit.\n");

--- a/examples/server_example_password_auth/server_example_password_auth.c
+++ b/examples/server_example_password_auth/server_example_password_auth.c
@@ -159,6 +159,12 @@ readAccessHandler(LogicalDevice* ld, LogicalNode* ln, DataObject* dataObject, Fu
 
 int main(int argc, char** argv) {
 
+    int tcpPort = 102;
+
+    if (argc > 1) {
+        tcpPort = atoi(argv[1]);
+    }
+
 	iedServer = IedServer_create(&iedModel);
 
 	/* Activate authentication */
@@ -194,7 +200,7 @@ int main(int argc, char** argv) {
     IedServer_setReadAccessHandler(iedServer, readAccessHandler, NULL);
 
 	/* MMS server will be instructed to start listening to client connections. */
-	IedServer_start(iedServer, 102);
+	IedServer_start(iedServer, tcpPort);
 
 	if (!IedServer_isRunning(iedServer)) {
 		printf("Starting server failed! Exit.\n");

--- a/examples/server_example_setting_groups/server_example_sg.c
+++ b/examples/server_example_setting_groups/server_example_sg.c
@@ -105,6 +105,12 @@ readAccessHandler(LogicalDevice* ld, LogicalNode* ln, DataObject* dataObject, Fu
 int 
 main(int argc, char** argv)
 {
+    int tcpPort = 102;
+
+    if (argc > 1) {
+        tcpPort = atoi(argv[1]);
+    }
+
     IedServerConfig config = IedServerConfig_create();
 
     //IedServerConfig_enableEditSG(config, false);
@@ -127,7 +133,7 @@ main(int argc, char** argv)
     IedServer_setReadAccessHandler(iedServer, readAccessHandler, NULL);
 
     /* MMS server will be instructed to start listening to client connections. */
-    IedServer_start(iedServer, 102);
+    IedServer_start(iedServer, tcpPort);
 
     if (!IedServer_isRunning(iedServer)) {
         printf("Starting server failed! Exit.\n");

--- a/examples/server_example_substitution/server_example_substitution.c
+++ b/examples/server_example_substitution/server_example_substitution.c
@@ -200,6 +200,12 @@ writeAccessHandler (DataAttribute* dataAttribute, MmsValue* value, ClientConnect
 int
 main(int argc, char** argv)
 {
+    int tcpPort = 102;
+
+    if (argc > 1) {
+        tcpPort = atoi(argv[1]);
+    }
+
     printf("Using libIEC61850 version %s\n", LibIEC61850_getVersionString());
 
     /* Create a new IEC 61850 server instance */
@@ -220,7 +226,7 @@ main(int argc, char** argv)
     IedServer_handleWriteAccess(iedServer, IEDMODEL_LD1_GGIO1_Ind1_blkEna, writeAccessHandler, NULL);
 
     /* MMS server will be instructed to start listening for client connections. */
-    IedServer_start(iedServer, 102);
+    IedServer_start(iedServer, tcpPort);
 
     if (!IedServer_isRunning(iedServer)) {
         printf("Starting server failed! Exit.\n");

--- a/examples/server_example_threadless/server_example_threadless.c
+++ b/examples/server_example_threadless/server_example_threadless.c
@@ -65,6 +65,11 @@ controlHandlerForBinaryOutput(ControlAction action, void* parameter, MmsValue* v
 int
 main(int argc, char** argv)
 {
+    int tcpPort = 102;
+
+    if (argc > 1) {
+        tcpPort = atoi(argv[1]);
+    }
 
     iedServer = IedServer_create(&iedModel);
 
@@ -86,7 +91,7 @@ main(int argc, char** argv)
             IEDMODEL_GenericIO_GGIO1_SPCSO4);
 
     /* MMS server will be instructed to start listening to client connections. */
-    IedServer_startThreadless(iedServer, 102);
+    IedServer_startThreadless(iedServer, tcpPort);
 
     if (!IedServer_isRunning(iedServer)) {
         printf("Starting server failed! Exit.\n");

--- a/examples/server_example_write_handler/server_example_write_handler.c
+++ b/examples/server_example_write_handler/server_example_write_handler.c
@@ -41,10 +41,16 @@ writeAccessHandler (DataAttribute* dataAttribute, MmsValue* value, ClientConnect
 int
 main(int argc, char** argv)
 {
+    int tcpPort = 102;
+
+    if (argc > 1) {
+        tcpPort = atoi(argv[1]);
+    }
+
     iedServer = IedServer_create(&iedModel);
 
     /* MMS server will be instructed to start listening to client connections. */
-    IedServer_start(iedServer, 102);
+    IedServer_start(iedServer, tcpPort);
 
     /* Don't allow access to SP variables by default */
     IedServer_setWriteAccessPolicy(iedServer, IEC61850_FC_SP, ACCESS_POLICY_DENY);


### PR DESCRIPTION
…e server examples

Some 'server' examples already have this capability. Complete the 'server' example list that support the possibility of using another MMS port than the default one (port '102').

Signed-off-by: Mikael Bourhis <mikael.bourhis@smile.fr>