### PR TITLE
quality: add 'const' qualifier to the 'MMS value' getters

### DIFF
--- a/src/iec61850/client/client_goose_control.c
+++ b/src/iec61850/client/client_goose_control.c
@@ -213,7 +213,7 @@ ClientGooseControlBlock_getDstAddress(ClientGooseControlBlock self)
         goto exit_error;
     }
 
-    uint8_t* addrBuf = MmsValue_getOctetStringBuffer(addr);
+    const uint8_t* addrBuf = MmsValue_getOctetStringBuffer(addr);
 
     memcpy(&(retVal.dstAddress), addrBuf, 6);
 

--- a/src/iec61850/client/client_sv_control.c
+++ b/src/iec61850/client/client_sv_control.c
@@ -312,7 +312,7 @@ ClientSVControlBlock_getDstAddress(ClientSVControlBlock self)
         goto exit_cleanup;
     }
 
-    uint8_t* addrBuf = MmsValue_getOctetStringBuffer(addr);
+    const uint8_t* addrBuf = MmsValue_getOctetStringBuffer(addr);
 
     memcpy(&(retVal.dstAddress), addrBuf, 6);
 

--- a/src/iec61850/inc/iec61850_server.h
+++ b/src/iec61850/inc/iec61850_server.h
@@ -1331,7 +1331,7 @@ ControlAction_getOrCat(ControlAction self);
  *
  * \return the originator identifier
  */
-LIB61850_API uint8_t*
+LIB61850_API const uint8_t*
 ControlAction_getOrIdent(ControlAction self, int* orIdentSize);
 
 /**

--- a/src/iec61850/server/mms_mapping/control.c
+++ b/src/iec61850/server/mms_mapping/control.c
@@ -2470,7 +2470,7 @@ ControlAction_getOrCat(ControlAction self)
     return 0;
 }
 
-uint8_t*
+const uint8_t*
 ControlAction_getOrIdent(ControlAction self, int* orIdentSize)
 {
     ControlObject* controlObject = (ControlObject*) self;

--- a/src/iec61850/server/mms_mapping/reporting.c
+++ b/src/iec61850/server/mms_mapping/reporting.c
@@ -1583,7 +1583,7 @@ updateOwner(ReportControl* rc, MmsServerConnection connection)
 static bool
 checkForZeroEntryID(MmsValue* value)
 {
-    uint8_t* buffer = MmsValue_getOctetStringBuffer(value);
+    const uint8_t* buffer = MmsValue_getOctetStringBuffer(value);
 
     int i = 0;
 

--- a/src/mms/inc/mms_value.h
+++ b/src/mms/inc/mms_value.h
@@ -300,7 +300,7 @@ MmsValue_getBoolean(const MmsValue* value);
  * \returns the string value as 0 terminated C string
  */
 LIB61850_API const char*
-MmsValue_toString(MmsValue* self);
+MmsValue_toString(const MmsValue* self);
 
 /**
  * \brief Returns the (maximum) length of the string
@@ -310,7 +310,7 @@ MmsValue_toString(MmsValue* self);
  * \param self MmsValue instance to operate on. Has to be of a type MMS_VISIBLE_STRING or MMS_STRING.
  */
 LIB61850_API int
-MmsValue_getStringSize(MmsValue* self);
+MmsValue_getStringSize(const MmsValue* self);
 
 LIB61850_API void
 MmsValue_setVisibleString(MmsValue* self, const char* string);
@@ -463,8 +463,8 @@ MmsValue_setUtcTimeByBuffer(MmsValue* self, const uint8_t* buffer);
  *
  * \return the buffer containing the raw data
  */
-LIB61850_API uint8_t*
-MmsValue_getUtcTimeBuffer(MmsValue* self);
+LIB61850_API const uint8_t*
+MmsValue_getUtcTimeBuffer(const MmsValue* self);
 
 /**
  * \brief Get a millisecond time value from an MmsValue object of MMS_UTCTIME type.
@@ -593,7 +593,7 @@ MmsValue_getOctetStringSize(const MmsValue* self);
  * \return maximum size in bytes
  */
 LIB61850_API uint16_t
-MmsValue_getOctetStringMaxSize(MmsValue* self);
+MmsValue_getOctetStringMaxSize(const MmsValue* self);
 
 /**
  * \brief Returns the reference to the internally hold buffer of an MmsValue object of type MMS_OCTET_STRING.
@@ -604,8 +604,8 @@ MmsValue_getOctetStringMaxSize(MmsValue* self);
  *
  * \return reference to the buffer
  */
-LIB61850_API uint8_t*
-MmsValue_getOctetStringBuffer(MmsValue* self);
+LIB61850_API const uint8_t*
+MmsValue_getOctetStringBuffer(const MmsValue* self);
 
 /**
  * \brief Get the value of a single octet of an MmsType object of type MMS_OCTET_STRING
@@ -619,7 +619,7 @@ MmsValue_getOctetStringBuffer(MmsValue* self);
  * \return the value of the octet (0 to 255, or 0x00 to 0xFF)
  */
 LIB61850_API uint8_t
-MmsValue_getOctetStringOctet(MmsValue* self, int octetPos);
+MmsValue_getOctetStringOctet(const MmsValue* self, int octetPos);
 
 /**
  * \brief Update the value of an MmsValue instance by the value of another MmsValue instance.
@@ -938,7 +938,7 @@ MmsValue_setDeletableRecursive(MmsValue* value);
  * \return 1 if deletable flag is set, otherwise 0
  */
 LIB61850_API int
-MmsValue_isDeletable(MmsValue* self);
+MmsValue_isDeletable(const MmsValue* self);
 
 /**
  * \brief Get the MmsType of an MmsValue instance
@@ -967,8 +967,8 @@ MmsValue_getSubElement(MmsValue* self, MmsVariableSpecification* varSpec, char* 
  *
  * \return the value type as a human readable string
  */
-LIB61850_API char*
-MmsValue_getTypeString(MmsValue* self);
+LIB61850_API const char*
+MmsValue_getTypeString(const MmsValue* self);
 
 /**
  * \brief create a string representation of the MmsValue object in the provided buffer
@@ -1022,7 +1022,7 @@ MmsValue_encodeMmsData(MmsValue* self, uint8_t* buffer, int bufPos, bool encode)
  * \return the maximum encoded size in bytes of the MMS data element
  */
 LIB61850_API int
-MmsValue_getMaxEncodedSize(MmsValue* self);
+MmsValue_getMaxEncodedSize(const MmsValue* self);
 
 /**
  * \brief Calculate the maximum encoded size of a variable of this type

--- a/src/mms/iso_mms/common/mms_value.c
+++ b/src/mms/iso_mms/common/mms_value.c
@@ -816,8 +816,8 @@ MmsValue_setUtcTimeByBuffer(MmsValue* self, const uint8_t* buffer)
     }
 }
 
-uint8_t*
-MmsValue_getUtcTimeBuffer(MmsValue* self)
+const uint8_t*
+MmsValue_getUtcTimeBuffer(const MmsValue* self)
 {
     return self->value.utcTime;
 }
@@ -1492,19 +1492,19 @@ MmsValue_getOctetStringSize(const MmsValue* self)
 }
 
 uint16_t
-MmsValue_getOctetStringMaxSize(MmsValue* self)
+MmsValue_getOctetStringMaxSize(const MmsValue* self)
 {
     return abs(self->value.octetString.maxSize);
 }
 
-uint8_t*
-MmsValue_getOctetStringBuffer(MmsValue* self)
+const uint8_t*
+MmsValue_getOctetStringBuffer(const MmsValue* self)
 {
     return self->value.octetString.buf;
 }
 
 uint8_t
-MmsValue_getOctetStringOctet(MmsValue* self, int octetPos)
+MmsValue_getOctetStringOctet(const MmsValue* self, int octetPos)
 {
     uint8_t octet = 0x00; /* default value, for out of range request */
 
@@ -1922,7 +1922,7 @@ MmsValue_setVisibleString(MmsValue* self, const char* string)
 }
 
 const char*
-MmsValue_toString(MmsValue* self)
+MmsValue_toString(const MmsValue* self)
 {
     if ((self->type == MMS_VISIBLE_STRING) || (self->type == MMS_STRING))
         return self->value.visibleString.buf;
@@ -1931,7 +1931,7 @@ MmsValue_toString(MmsValue* self)
 }
 
 int
-MmsValue_getStringSize(MmsValue* self)
+MmsValue_getStringSize(const MmsValue* self)
 {
     if ((self->type == MMS_VISIBLE_STRING) || (self->type == MMS_STRING))
         return self->value.visibleString.size;
@@ -2103,7 +2103,7 @@ MmsValue_setDeletableRecursive(MmsValue* self)
 }
 
 int
-MmsValue_isDeletable(MmsValue* self)
+MmsValue_isDeletable(const MmsValue* self)
 {
     return self->deleteValue;
 }
@@ -2120,8 +2120,8 @@ MmsValue_getSubElement(MmsValue* self, MmsVariableSpecification* varSpec, char* 
     return MmsVariableSpecification_getChildValue(varSpec, self, mmsPath);
 }
 
-char*
-MmsValue_getTypeString(MmsValue* self)
+const char*
+MmsValue_getTypeString(const MmsValue* self)
 {
     switch (MmsValue_getType(self))
     {

--- a/src/mms/iso_mms/server/mms_access_result.c
+++ b/src/mms/iso_mms/server/mms_access_result.c
@@ -335,7 +335,7 @@ exit_with_error:
 }
 
 static int
-MmsValue_getMaxStructSize(MmsValue* self)
+MmsValue_getMaxStructSize(const MmsValue* self)
 {
     int componentsSize = 0;
     int i;
@@ -354,7 +354,7 @@ MmsValue_getMaxStructSize(MmsValue* self)
 }
 
 int
-MmsValue_getMaxEncodedSize(MmsValue* self)
+MmsValue_getMaxEncodedSize(const MmsValue* self)
 {
     int size = 0;
     int elementSize = 0;


### PR DESCRIPTION
Some getters already have the 'const' qualifier, but not all. To improve the quality of the code, add the 'const' qualifier for the other getters of 'MMS value', where it was missing.

Remark:
when a pointer is returned by a getter, this pointer must be a pointer to a constant, so as not to modify the internal data of the 'MMS value' object. The correctness of the function calls, in libiec61850, has been checked with the compiler option: '-Wdiscarded-qualifiers'.

Signed-off-by: Mikael Bourhis <mikael.bourhis@smile.fr>