### PR TITLE
tls: add method to reset used CRL (certificate revocation list)

### DIFF
--- a/hal/inc/tls_config.h
+++ b/hal/inc/tls_config.h
@@ -297,6 +297,13 @@ PAL_API bool
 TLSConfiguration_addCRLFromFile(TLSConfiguration self, const char* filename);
 
 /**
+ * \brief Removes any CRL (certificate revocation list) currently in use
+ *
+ */
+PAL_API void
+TLSConfiguration_resetCRL(TLSConfiguration self);
+
+/**
  * Release all resource allocated by the TLSConfiguration instance
  *
  * NOTE: Do not use the object after calling this function!

--- a/hal/tls/mbedtls/tls_mbedtls.c
+++ b/hal/tls/mbedtls/tls_mbedtls.c
@@ -476,6 +476,14 @@ TLSConfiguration_addCRLFromFile(TLSConfiguration self, const char* filename)
 }
 
 void
+TLSConfiguration_resetCRL(TLSConfiguration self)
+{
+    mbedtls_x509_crl_free(&(self->crl));
+    mbedtls_x509_crl_init(&(self->crl));
+    self->crlUpdated = Hal_getTimeInMs();
+}
+
+void
 TLSConfiguration_setRenegotiationTime(TLSConfiguration self, int timeInMs)
 {
     self->renegotiationTimeInMs = timeInMs;


### PR DESCRIPTION
Add a method to be able to reset the CRL, otherwise any previously added CRL will stay there until the object is totally destroyed. This proves to be needed for cases when we need to delete the CRL (ie. it expired) during the lifetime of the server.