### PR TITLE
fix: ssl renegotiation causing handshake failure

### DIFF
--- a/hal/tls/mbedtls/tls_mbedtls.c
+++ b/hal/tls/mbedtls/tls_mbedtls.c
@@ -39,7 +39,7 @@
 #if (CONFIG_DEBUG_TLS == 1)
 #define DEBUG_PRINT(appId, fmt, ...) fprintf(stderr, "%s: " fmt, appId, ## __VA_ARGS__)
 #else
-#define DEBUG_PRINT(fmt, ...) {do {} while(0);}
+#define DEBUG_PRINT(fmt, ...) do {} while(0)
 #endif
 
 

--- a/hal/tls/mbedtls/tls_mbedtls.c
+++ b/hal/tls/mbedtls/tls_mbedtls.c
@@ -923,22 +923,19 @@ TLSSocket_read(TLSSocket self, uint8_t* buf, int size)
     int len = 0;
     while (len < size) {
         int ret = mbedtls_ssl_read(&(self->ssl), (buf + len), (size - len));
-        if (ret == 0) {
-            break;
-        } else if (ret > 0) {
+        if (ret > 0) {
             len += ret;
             continue;
         }
 
-        // Negative values means errors
-        switch (ret)
-        {
-        case MBEDTLS_ERR_SSL_WANT_READ: // Falling through
+        switch (ret) {
+        case 0: // falling through
+        case MBEDTLS_ERR_SSL_WANT_READ:
         case MBEDTLS_ERR_SSL_WANT_WRITE:
         case MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS:
         case MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS:
-            continue;
-            break;
+            // Known "good" cases indicating the read is done
+            return len;
 
         case MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY:
             DEBUG_PRINT("TLS", " connection was closed gracefully\n");

--- a/hal/tls/mbedtls/tls_mbedtls.c
+++ b/hal/tls/mbedtls/tls_mbedtls.c
@@ -37,7 +37,7 @@
 #endif
 
 #if (CONFIG_DEBUG_TLS == 1)
-#define DEBUG_PRINT(appId, fmt, ...) fprintf(stderr, "%s: " fmt, appId, ## __VA_ARGS__);
+#define DEBUG_PRINT(appId, fmt, ...) fprintf(stderr, "%s: " fmt, appId, ## __VA_ARGS__)
 #else
 #define DEBUG_PRINT(fmt, ...) {do {} while(0);}
 #endif

--- a/hal/tls/mbedtls/tls_mbedtls.c
+++ b/hal/tls/mbedtls/tls_mbedtls.c
@@ -297,7 +297,7 @@ TLSConfiguration_create()
 void
 TLSConfiguration_setClientMode(TLSConfiguration self)
 {
-    self->conf.endpoint = MBEDTLS_SSL_IS_CLIENT;
+    mbedtls_ssl_conf_endpoint(&(self->conf), MBEDTLS_SSL_IS_CLIENT);
 }
 
 void


### PR DESCRIPTION
TLS renegotiation was not working properly, causing handshake to fail pretty much always.  
Improved renegotiation by adding more error checks on mbedtls returns.  

Adding the session reset and refactoring the read/write apparently solved the problem

I still suspect that there may be still some corner cases causing concurrency issues. (ie. calling a close when a read is currently happening)