### PR TITLE
Update ied_connection.c

### DIFF
--- a/src/iec61850/client/ied_connection.c
+++ b/src/iec61850/client/ied_connection.c
@@ -2783,21 +2783,22 @@ IedConnection_getLogicalNodeDirectory(IedConnection self, IedClientError* error,
                         goto next_element;
 
                     int lnNameLen = (int)(fcPos - variableName);
-
-                    if (strncmp(variableName, logicalNodeName, lnNameLen) == 0)
-                    {
-                        char* fcEndPos = strchr(fcPos + 1, '$');
-
-                        if (fcEndPos)
+                    if (strlen(logicalNodeName) == lnNameLen){
+                        if (strncmp(variableName, logicalNodeName, lnNameLen) == 0)
                         {
-                            char* nameEndPos = strchr(fcEndPos + 1, '$');
-
-                            if (nameEndPos == NULL)
+                            char* fcEndPos = strchr(fcPos + 1, '$');
+    
+                            if (fcEndPos)
                             {
-                                char* dataObjectName = StringUtils_copyString(fcEndPos + 1);
-
-                                if (!addToStringSet(lnDirectory, dataObjectName))
-                                    GLOBAL_FREEMEM(dataObjectName);
+                                char* nameEndPos = strchr(fcEndPos + 1, '$');
+    
+                                if (nameEndPos == NULL)
+                                {
+                                    char* dataObjectName = StringUtils_copyString(fcEndPos + 1);
+    
+                                    if (!addToStringSet(lnDirectory, dataObjectName))
+                                        GLOBAL_FREEMEM(dataObjectName);
+                                }
                             }
                         }
                     }
@@ -2929,10 +2930,11 @@ IedConnection_getLogicalNodeVariables(IedConnection self, IedClientError* error,
         if (fcPos)
         {
             int lnNameLen = (int)(fcPos - variableName);
-
-            if (strncmp(variableName, logicalNodeName, lnNameLen) == 0)
-            {
-                LinkedList_add(lnDirectory, StringUtils_copyString(fcPos + 1));
+            if (strlen(logicalNodeName) == lnNameLen){
+                if (strncmp(variableName, logicalNodeName, lnNameLen) == 0)
+                {
+                    LinkedList_add(lnDirectory, StringUtils_copyString(fcPos + 1));
+                }
             }
         }
 


### PR DESCRIPTION
During my test, it was observed that when there are 2 logical nodes with same string repeats, ( such as almGGIO1 and almGGIO10) in those cases, these 2 below functions add the DOs from almGGIO1 to almGGIO10. and model discovery will show invalid DOs under almGGIO10. My test was done in 1.5 version, I think this change is relevent in current version also.

IedConnection_getLogicalNodeDirectory
IedConnection_getLogicalNodeVariables