### PR TITLE
Constify file system functions arguments

### DIFF
--- a/hal/filesystem/linux/file_provider_linux.c
+++ b/hal/filesystem/linux/file_provider_linux.c
@@ -38,7 +38,7 @@ struct sDirectoryHandle {
 };
 
 FileHandle
-FileSystem_openFile(char* fileName, bool readWrite)
+FileSystem_openFile(const char* fileName, bool readWrite)
 {
     FileHandle newHandle = NULL;
 
@@ -57,7 +57,7 @@ FileSystem_readFile(FileHandle handle, uint8_t* buffer, int maxSize)
 }
 
 int
-FileSystem_writeFile(FileHandle handle, uint8_t* buffer, int size)
+FileSystem_writeFile(FileHandle handle, const uint8_t* buffer, int size)
 {
     return fwrite(buffer, 1, size, (FILE*) handle);
 }
@@ -69,7 +69,7 @@ FileSystem_closeFile(FileHandle handle)
 }
 
 bool
-FileSystem_deleteFile(char* filename)
+FileSystem_deleteFile(const char* filename)
 {
     if (remove(filename) == 0)
         return true;
@@ -78,7 +78,7 @@ FileSystem_deleteFile(char* filename)
 }
 
 bool
-FileSystem_renameFile(char* oldFilename, char* newFilename)
+FileSystem_renameFile(const char* oldFilename, const char* newFilename)
 {
     if (rename(oldFilename, newFilename) == 0)
         return true;
@@ -88,7 +88,7 @@ FileSystem_renameFile(char* oldFilename, char* newFilename)
 
 
 bool
-FileSystem_getFileInfo(char* filename, uint32_t* fileSize, uint64_t* lastModificationTimestamp)
+FileSystem_getFileInfo(const char* filename, uint32_t* fileSize, uint64_t* lastModificationTimestamp)
 {
     struct stat fileStats;
 
@@ -106,7 +106,7 @@ FileSystem_getFileInfo(char* filename, uint32_t* fileSize, uint64_t* lastModific
 }
 
 DirectoryHandle
-FileSystem_openDirectory(char* directoryName)
+FileSystem_openDirectory(const char* directoryName)
 {
     DIR* dirHandle = opendir(directoryName);
 
@@ -120,7 +120,7 @@ FileSystem_openDirectory(char* directoryName)
     return handle;
 }
 
-char*
+const char*
 FileSystem_readDirectory(DirectoryHandle directory, bool* isDirectory)
 {
     struct dirent* dir;

--- a/hal/filesystem/win32/file_provider_win32.c
+++ b/hal/filesystem/win32/file_provider_win32.c
@@ -47,7 +47,7 @@ struct sDirectoryHandle {
 
 
 FileHandle
-FileSystem_openFile(char* fileName, bool readWrite)
+FileSystem_openFile(const char* fileName, bool readWrite)
 {
     FileHandle newHandle = NULL;
 
@@ -66,7 +66,7 @@ FileSystem_readFile(FileHandle handle, uint8_t* buffer, int maxSize)
 }
 
 int
-FileSystem_writeFile(FileHandle handle, uint8_t* buffer, int size)
+FileSystem_writeFile(FileHandle handle, const uint8_t* buffer, int size)
 {
     return fwrite(buffer, 1, size, (FILE*) handle);
 }
@@ -78,7 +78,7 @@ FileSystem_closeFile(FileHandle handle)
 }
 
 bool
-FileSystem_getFileInfo(char* filename, uint32_t* fileSize, uint64_t* lastModificationTimestamp)
+FileSystem_getFileInfo(const char* filename, uint32_t* fileSize, uint64_t* lastModificationTimestamp)
 {
     WIN32_FILE_ATTRIBUTE_DATA fad;
 
@@ -104,7 +104,7 @@ FileSystem_getFileInfo(char* filename, uint32_t* fileSize, uint64_t* lastModific
 }
 
 DirectoryHandle
-FileSystem_openDirectory(char* directoryName)
+FileSystem_openDirectory(const char* directoryName)
 {
     DirectoryHandle dirHandle = (DirectoryHandle) GLOBAL_CALLOC(1, sizeof(struct sDirectoryHandle));
 
@@ -168,7 +168,7 @@ getNextDirectoryEntry(DirectoryHandle directory, bool* isDirectory)
 
 
 bool
-FileSystem_deleteFile(char* filename)
+FileSystem_deleteFile(const char* filename)
 {
     if (remove(filename) == 0)
         return true;
@@ -177,7 +177,7 @@ FileSystem_deleteFile(char* filename)
 }
 
 bool
-FileSystem_renameFile(char* oldFilename, char* newFilename)
+FileSystem_renameFile(const char* oldFilename, const char* newFilename)
 {
     if (rename(oldFilename, newFilename) == 0)
         return true;
@@ -186,7 +186,7 @@ FileSystem_renameFile(char* oldFilename, char* newFilename)
 }
 
 
-char*
+const char*
 FileSystem_readDirectory(DirectoryHandle directory, bool* isDirectory)
 {
     char* fileName = getNextDirectoryEntry(directory, isDirectory);

--- a/hal/inc/hal_filesystem.h
+++ b/hal/inc/hal_filesystem.h
@@ -44,7 +44,7 @@ typedef struct sDirectoryHandle* DirectoryHandle;
  *         NULL if opening fails
  */
 PAL_API FileHandle
-FileSystem_openFile(char* pathName, bool readWrite);
+FileSystem_openFile(const char* pathName, bool readWrite);
 
 /**
  * \brief read from an open file
@@ -73,7 +73,7 @@ FileSystem_readFile(FileHandle handle, uint8_t* buffer, int maxSize);
  * \return the number of bytes actually written
  */
 PAL_API int
-FileSystem_writeFile(FileHandle handle, uint8_t* buffer, int size);
+FileSystem_writeFile(FileHandle handle, const uint8_t* buffer, int size);
 
 /**
  * \brief close an open file
@@ -97,7 +97,7 @@ FileSystem_closeFile(FileHandle handle);
  * \return true if file exists, false if not
  */
 PAL_API bool
-FileSystem_getFileInfo(char* filename, uint32_t* fileSize, uint64_t* lastModificationTimestamp);
+FileSystem_getFileInfo(const char* filename, uint32_t* fileSize, uint64_t* lastModificationTimestamp);
 
 /**
  * \brief delete a file
@@ -107,7 +107,7 @@ FileSystem_getFileInfo(char* filename, uint32_t* fileSize, uint64_t* lastModific
  * \return true on success, false on error
  */
 PAL_API bool
-FileSystem_deleteFile(char* filename);
+FileSystem_deleteFile(const char* filename);
 
 /**
  * \brief rename a file
@@ -118,7 +118,7 @@ FileSystem_deleteFile(char* filename);
  * \return true on success, false on error
  */
 PAL_API bool
-FileSystem_renameFile(char* oldFilename, char* newFilename);
+FileSystem_renameFile(const char* oldFilename, const char* newFilename);
 
 /**
  * \brief open the directoy with the specified name
@@ -128,7 +128,7 @@ FileSystem_renameFile(char* oldFilename, char* newFilename);
  * \return a handle for the opened directory to be used in subsequent calls to identify the directory
  */
 PAL_API DirectoryHandle
-FileSystem_openDirectory(char* directoryName);
+FileSystem_openDirectory(const char* directoryName);
 
 /**
  * \brief read the next directory entry
@@ -142,7 +142,7 @@ FileSystem_openDirectory(char* directoryName);
  *
  * \return the name of the directory entry
  */
-PAL_API char*
+PAL_API const char*
 FileSystem_readDirectory(DirectoryHandle directory, bool* isDirectory);
 
 

--- a/src/mms/iso_mms/server/mms_file_service.c
+++ b/src/mms/iso_mms/server/mms_file_service.c
@@ -960,7 +960,7 @@ addFileEntriesToResponse(const char* basepath, uint8_t* buffer, int bufPos, int 
     if (directory != NULL) {
 
         bool isDirectory;
-        char* fileName = FileSystem_readDirectory(directory, &isDirectory);
+        const char* fileName = FileSystem_readDirectory(directory, &isDirectory);
 
         while (fileName != NULL) {
         	directoryName[directoryNameLength] = 0;


### PR DESCRIPTION
For example, file name arguments must be never modified because it may lead in unexpected behaviour.