### PR TITLE
add r_session to stack_includes.mk

### DIFF
--- a/make/stack_includes.mk
+++ b/make/stack_includes.mk
@@ -10,3 +10,4 @@ INCLUDES += -I$(LIBIEC_HOME)/src/goose
 INCLUDES += -I$(LIBIEC_HOME)/src/sampled_values
 INCLUDES += -I$(LIBIEC_HOME)/src/logging
 INCLUDES += -I$(LIBIEC_HOME)/src/tls
+INCLUDES += -I$(LIBIEC_HOME)/src/r_session


### PR DESCRIPTION
Hi!

I was trying to run the SV examples `(`sv_publisher`` and `sv_subscriber`) and they couldn't be built because the compiler couldn't find `r_session.h`.

After git-bisecting the codebase, I found that the building of those examples started to break in commit 90372ced7252679ee1c5e6ae749883bfcbaa98c6, as `r_session.h` was introduced in both examples while it directory was not included in the Makefile.

This PR fixes it by adding src/r_session to `stack_includes.mk`. With this, those examples build successfully.