### PR TITLE
fix: ensure variables are initialized before goto

### DIFF
--- a/src/iec61850/client/client_goose_control.c
+++ b/src/iec61850/client/client_goose_control.c
@@ -973,6 +973,9 @@ IedConnection_setGoCBValuesAsync(IedConnection self, IedClientError* error, Clie
     char domainId[65];
     char itemId[130];
 
+    LinkedList itemIds = NULL;
+    LinkedList values = NULL;
+
     if (MmsMapping_getMmsDomainFromObjectReference(goCB->objectReference, domainId) == NULL)
     {
         *error = IED_ERROR_OBJECT_REFERENCE_INVALID;;
@@ -1006,8 +1009,8 @@ IedConnection_setGoCBValuesAsync(IedConnection self, IedClientError* error, Clie
     int itemIdLen = strlen(itemId);
 
     /* create the list of requested itemIds references */
-    LinkedList itemIds = LinkedList_create();
-    LinkedList values = LinkedList_create();
+    itemIds = LinkedList_create();
+    values = LinkedList_create();
 
     /* add rGoEna as last element */
     if (parametersMask & GOCB_ELEMENT_GO_ID)

--- a/src/iec61850/server/model/config_file_parser.c
+++ b/src/iec61850/server/model/config_file_parser.c
@@ -223,6 +223,10 @@ exit_error:
 IedModel*
 ConfigFileParser_createModelFromConfigFile(FileHandle fileHandle)
 {
+    IedModel* model = NULL;
+    int indendation = 0;
+    int currentLine = 0;
+
     uint8_t* lineBuffer = (uint8_t*)GLOBAL_MALLOC(READ_BUFFER_MAX_SIZE);
 
     if (lineBuffer == NULL)
@@ -231,11 +235,9 @@ ConfigFileParser_createModelFromConfigFile(FileHandle fileHandle)
     int bytesRead = 1;
 
     bool stateInModel = false;
-    int indendation = 0;
     bool inArray = false;
     bool inArrayElement = false;
 
-    IedModel* model = NULL;
     LogicalDevice* currentLD = NULL;
     LogicalNode* currentLN = NULL;
     ModelNode* currentModelNode = NULL;
@@ -248,7 +250,6 @@ ConfigFileParser_createModelFromConfigFile(FileHandle fileHandle)
     char nameString2[130];
     char nameString3[130];
 
-    int currentLine = 0;
 
     while (bytesRead > 0)
     {


### PR DESCRIPTION
Hello,

This commit adds variable initialization before goto statement can be executed. As a result, it prevents jumping to code that uses uninitialized variables. 

Here is an example from  ```IedConnection_setGoCBValuesAsync``` at ```client_goose_control.c```

```
    if (separator == NULL)
    {
        *error = IED_ERROR_OBJECT_REFERENCE_INVALID;
        goto exit_function;
    }
...
   
    /* create the list of requested itemIds references */
    LinkedList itemIds = LinkedList_create();
    LinkedList values = LinkedList_create();

...
exit_function:
    LinkedList_destroy(itemIds);
    LinkedList_destroyStatic(values);
```

If ```separator``` is NULL, a ```goto exit_function``` is triggered. However, ```exit_function``` uses ```itemIds``` and ```values```, which may be uninitialized since they are assigned after the goto.

This is a rare but possible issue, detectable with Clang and -Wsometimes-uninitialized flag.

Please let me know if any additional information, testing, or clarification is needed.

Thank you