### PR TITLE
fix R-Session debug print statements

### DIFF
--- a/src/r_session/r_session.c
+++ b/src/r_session/r_session.c
@@ -89,7 +89,7 @@ struct sRSession
     int timeToNextKey;
 };
 
-#ifdef DEBUG_RSESSION
+#if (DEBUG_RSESSION == 1)
 static void
 printBuffer(uint8_t* buffer, int bufSize)
 {
@@ -1000,7 +1000,7 @@ encodePacket(RSession self, uint8_t payloadType, uint8_t* buffer, int bufPos, RS
         int addPartSize = encryptedPartStartPos - startPos;
         int encryptedPartSize = payloadEndPos - encryptedPartStartPos;
 
-#ifdef DEBUG_RSESSION
+#if (DEBUG_RSESSION == 1)
         printBuffer(buffer + startPos, bufPos - startPos);
 #endif
 
@@ -1053,7 +1053,7 @@ RSession_sendMessage(RSession self, RSessionProtocol_SPDU_ID spduId, bool simula
 
         int msgSize = encodePacket(self, (uint8_t) spduId, self->sendBuffer, 0, &element);
 
-#ifdef DEBUG_RSESSION
+#if (DEBUG_RSESSION == 1)
         printBuffer(self->sendBuffer, msgSize);
 #endif
 


### PR DESCRIPTION
Some `printBuffer` debug statements in `src/r_session/r_session.c` weren't properly excluded when `DEBUG_RSESSION` isn't defined. Checking for `#ifdef DEBUG_RSESSION` will never be false.

https://github.com/mz-automation/libiec61850/blob/3a1480e5948ca53b4dcc5fa15b05598fa3322bb9/src/r_session/r_session.c#L33-L35