### PR TITLE
Fix static model generator when MMS name as no prefix

### DIFF
--- a/tools/model_generator_dotnet/StaticModelGenerator/src/StaticModelGenerator.cs
+++ b/tools/model_generator_dotnet/StaticModelGenerator/src/StaticModelGenerator.cs
@@ -316,6 +316,9 @@ namespace StaticModelGenerator
 
         private static string toMmsString(string iecString)
         {
+            if (string.IsNullOrEmpty(iecString)) {
+                return string.Empty;
+            }
             return iecString.Replace('.', '$');
         }
 


### PR DESCRIPTION
Fixed null reference exception in static generator for real-world SEL751 CID files, where the MMS prefix was not set.
```
<DataSet desc="Metered Values and Sequence Quantities" name="URDSet01">
  <FCDA ldInst="MET" prefix="MET" lnClass="MMXU" lnInst="1" doName="A" fc="MX" />
...  
  <FCDA ldInst="MET" prefix="MET" lnClass="MSQI" lnInst="1" doName="SeqA" fc="MX" />
  <FCDA ldInst="MET" prefix="MET" lnClass="MSQI" lnInst="1" doName="SeqV" fc="MX" />
  <FCDA ldInst="PRO" lnClass="LLN0" fc="ST" />
</DataSet>
```